### PR TITLE
Seed initial client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build and check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Execute all tests
+        run: ./tests/ci.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+*patch
+Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+# Executing our tests on Arm64 with Travis CI
+arch: arm64
+language: rust
+script:
+  - ./tests/ci.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+<!--
+  -- Copyright (c) 2020, Arm Limited, All Rights Reserved
+  -- SPDX-License-Identifier: Apache-2.0
+  --
+  -- Licensed under the Apache License, Version 2.0 (the "License"); you may
+  -- not use this file except in compliance with the License.
+  -- You may obtain a copy of the License at
+  --
+  -- http://www.apache.org/licenses/LICENSE-2.0
+  --
+  -- Unless required by applicable law or agreed to in writing, software
+  -- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  -- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -- See the License for the specific language governing permissions and
+  -- limitations under the License.
+--->
+# Contributing to `parsec-client-rust`
+
+Contributions to Parsec need to follow the process below.
+
+* Contributions are done through GitHub pull-requests.
+* Contributors need to apply `rustfmt` and `clippy` to their Rust code.
+* New code needs to be tested
+* The code is accepted under the [Developer Certificate of Origin](DCO.txt), so you must add following fields to your commit description:
+```
+Author: Full Name <email address>
+Signed-off-by: Full Name <email address>
+```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "parsec-client"
+version = "0.1.0"
+authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
+           "Hugues de Valon <hugues.devalon@arm.com>"]
+description = "Parsec Client library for the Rust ecosystem"
+license = "Apache-2.0"
+repository = "https://github.com/parallaxsecond/parsec-client-rust"
+readme = "README.md"
+keywords = ["parsec"]
+categories = ["development-tools"]
+edition = "2018"
+
+[dependencies]
+parsec-interface = "0.10.0"
+num = "0.2.1"
+rand = "0.7.3"
+log = "0.4.8"
+derivative = "2.0.2"

--- a/DCO.txt
+++ b/DCO.txt
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -1,0 +1,63 @@
+# parsec-client-rust maintainers file
+#
+# This file lists the maintainers of the parallaxsecond/parsec-client-rust
+# project.
+#
+# Its structure is inspired from the maintainers files in the Docker Github
+# repositories. Please see the MAINTAINERS file in docker/opensource for more
+# information.
+
+[maintainers]
+
+# Core maintainers of the project.
+
+    [maintainers.core]
+    people = [
+      "adamparco",
+      "anta5010",
+      "heavypackets",
+      "hug-dev",
+      "ionut-arm",
+      "justincormack",
+      "paulhowardarm",
+    ]
+
+[people]
+
+# A reference list of all people associated with the project.
+
+    [people.adamparco]
+    Name = "Adam Parco"
+    Email = "adam.parco@docker.com"
+    GitHub = "adamparco"
+
+    [people.anta5010]
+    Name = "Anton Antonov"
+    Email = "anton.antonov@arm.com"
+    GitHub = "anta5010"
+
+    [people.heavypackets]
+    Name = "Sabree Blackmon"
+    Email = "sabree.blackmon@docker.com"
+    GitHub = "heavypackets"
+
+    [people.hug-dev]
+    Name = "Hugues de Valon"
+    Email = "hugues.devalon@arm.com"
+    GitHub = "hug-dev"
+
+    [people.ionut-arm]
+    Name = "Ionut Mihalcea"
+    Email = "ionut.mihalcea@docker.com"
+    GitHub = "ionut-arm"
+
+    [people.justincormack]
+    Name = "Justin Cormack"
+    Email = "justin.cormack@docker.com"
+    GitHub = "justincormack"
+
+    [people.paulhowardarm]
+    Name = "Paul Howard"
+    Email = "paul.howard@arm.com"
+    GitHub = "paulhowardarm"
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+<!--
+  -- Copyright (c) 2020, Arm Limited, All Rights Reserved
+  -- SPDX-License-Identifier: Apache-2.0
+  --
+  -- Licensed under the Apache License, Version 2.0 (the "License"); you may
+  -- not use this file except in compliance with the License.
+  -- You may obtain a copy of the License at
+  --
+  -- http://www.apache.org/licenses/LICENSE-2.0
+  --
+  -- Unless required by applicable law or agreed to in writing, software
+  -- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  -- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -- See the License for the specific language governing permissions and
+  -- limitations under the License.
+--->
+# Parsec Rust Client
+
+This repository contains a Rust client for consuming the API provided by the [Parsec service](https://github.com/parallaxsecond/parsec).
+The low-level functionality that this library uses for IPC is implemented in the [interface crate](https://github.com/parallaxsecond/parsec-interface-rs).
+
+## License
+
+The software is provided under Apache-2.0. Contributions to this project are accepted under the same license.
+
+This project uses the following third party crates:
+* num (MIT and Apache-2.0)
+* rand (Apache-2.0)
+* log (Apache-2.0)
+* derivative (MIT and Apache-2.0)
+
+## Contributing
+
+Please check the [Contributing](CONTRIBUTING.md) to know more about the contribution process.
+

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2020, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Client app authentication data
+use parsec_interface::requests::{request::RequestAuth, AuthType};
+
+/// Authentication data used in Parsec requests
+#[derive(Clone, Debug)]
+pub enum AuthenticationData {
+    /// Used in cases where no authentication is desired or required
+    None,
+    /// Data used for direct, identity-based authentication
+    AppIdentity(String),
+}
+
+impl AuthenticationData {
+    /// Get the Parsec authentication type based on the data type
+    pub fn auth_type(&self) -> AuthType {
+        match self {
+            AuthenticationData::None => AuthType::NoAuth,
+            AuthenticationData::AppIdentity(_) => AuthType::Direct,
+        }
+    }
+}
+
+impl From<&AuthenticationData> for RequestAuth {
+    fn from(data: &AuthenticationData) -> Self {
+        match data {
+            AuthenticationData::None => Default::default(),
+            AuthenticationData::AppIdentity(name) => {
+                RequestAuth::from_bytes(name.bytes().collect())
+            }
+        }
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,223 @@
+// Copyright (c) 2020, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Client library for integration with the Parsec service
+
+mod operation_handler;
+mod request_handler;
+
+use crate::auth::AuthenticationData;
+use operation_handler::OperationHandler;
+use parsec_interface::operations::list_opcodes::Operation as ListOpcodes;
+use parsec_interface::operations::list_providers::{Operation as ListProviders, ProviderInfo};
+use parsec_interface::operations::ping::Operation as Ping;
+use parsec_interface::operations::psa_algorithm::AsymmetricSignature;
+use parsec_interface::operations::psa_destroy_key::Operation as PsaDestroyKey;
+use parsec_interface::operations::psa_export_public_key::Operation as PsaExportPublicKey;
+use parsec_interface::operations::psa_generate_key::Operation as PsaGenerateKey;
+use parsec_interface::operations::psa_import_key::Operation as PsaImportKey;
+use parsec_interface::operations::psa_key_attributes::KeyAttributes;
+use parsec_interface::operations::psa_sign_hash::Operation as PsaSignHash;
+use parsec_interface::operations::psa_verify_hash::Operation as PsaVerifyHash;
+use parsec_interface::operations::{NativeOperation, NativeResult};
+use parsec_interface::requests::ProviderID;
+use parsec_interface::requests::Result;
+use parsec_interface::requests::{Opcode, ResponseStatus};
+use std::collections::HashSet;
+
+/// Core client for Parsec service
+///
+/// The client exposes low-level functionality for using the Parsec service
+#[derive(Debug)]
+pub struct CoreClient {
+    op_handler: OperationHandler,
+    auth_data: AuthenticationData,
+}
+
+impl CoreClient {
+    /// Create a new Parsec client given the authentication data of the app
+    pub fn new(auth_data: AuthenticationData) -> Self {
+        CoreClient {
+            op_handler: Default::default(),
+            auth_data,
+        }
+    }
+
+    /// list opcodes
+    pub fn list_provider_operations(&self, provider: ProviderID) -> Result<HashSet<Opcode>> {
+        let res = self.op_handler.process_operation(
+            NativeOperation::ListOpcodes(ListOpcodes {}),
+            provider,
+            &self.auth_data,
+        )?;
+
+        if let NativeResult::ListOpcodes(res) = res {
+            Ok(res.opcodes)
+        } else {
+            Err(ResponseStatus::InvalidHeader)
+        }
+    }
+
+    /// list providers
+    pub fn list_providers(&self) -> Result<Vec<ProviderInfo>> {
+        let res = self.op_handler.process_operation(
+            NativeOperation::ListProviders(ListProviders {}),
+            ProviderID::Core,
+            &self.auth_data,
+        )?;
+
+        if let NativeResult::ListProviders(res) = res {
+            Ok(res.providers)
+        } else {
+            Err(ResponseStatus::InvalidHeader)
+        }
+    }
+
+    /// ping
+    pub fn ping(&self) -> Result<()> {
+        let _ = self.op_handler.process_operation(
+            NativeOperation::Ping(Ping {}),
+            ProviderID::Core,
+            &AuthenticationData::None,
+        )?;
+
+        Ok(())
+    }
+
+    /// generate key
+    pub fn generate_key(
+        &self,
+        provider: ProviderID,
+        key_name: String,
+        key_attributes: KeyAttributes,
+    ) -> Result<()> {
+        let op = PsaGenerateKey {
+            key_name,
+            attributes: key_attributes,
+        };
+
+        let _ = self.op_handler.process_operation(
+            NativeOperation::PsaGenerateKey(op),
+            provider,
+            &self.auth_data,
+        )?;
+
+        Ok(())
+    }
+
+    /// destroy key
+    pub fn destroy_key(&self, provider: ProviderID, key_name: String) -> Result<()> {
+        let op = PsaDestroyKey { key_name };
+
+        let _ = self.op_handler.process_operation(
+            NativeOperation::PsaDestroyKey(op),
+            provider,
+            &self.auth_data,
+        )?;
+
+        Ok(())
+    }
+
+    /// import key
+    pub fn import_key(
+        &self,
+        provider: ProviderID,
+        key_name: String,
+        key_material: Vec<u8>,
+        key_attributes: KeyAttributes,
+    ) -> Result<()> {
+        let op = PsaImportKey {
+            key_name,
+            attributes: key_attributes,
+            data: key_material,
+        };
+
+        let _ = self.op_handler.process_operation(
+            NativeOperation::PsaImportKey(op),
+            provider,
+            &self.auth_data,
+        )?;
+
+        Ok(())
+    }
+
+    /// export key
+    pub fn export_public_key(&self, provider: ProviderID, key_name: String) -> Result<Vec<u8>> {
+        let op = PsaExportPublicKey { key_name };
+
+        let res = self.op_handler.process_operation(
+            NativeOperation::PsaExportPublicKey(op),
+            provider,
+            &self.auth_data,
+        )?;
+
+        if let NativeResult::PsaExportPublicKey(res) = res {
+            Ok(res.data)
+        } else {
+            Err(ResponseStatus::InvalidHeader)
+        }
+    }
+
+    /// sign hash
+    pub fn sign_hash(
+        &self,
+        provider: ProviderID,
+        key_name: String,
+        hash: Vec<u8>,
+        sign_algorithm: AsymmetricSignature,
+    ) -> Result<Vec<u8>> {
+        let op = PsaSignHash {
+            key_name,
+            alg: sign_algorithm,
+            hash,
+        };
+
+        let res = self.op_handler.process_operation(
+            NativeOperation::PsaSignHash(op),
+            provider,
+            &self.auth_data,
+        )?;
+
+        if let NativeResult::PsaSignHash(res) = res {
+            Ok(res.signature)
+        } else {
+            Err(ResponseStatus::InvalidHeader)
+        }
+    }
+
+    /// verify hash
+    pub fn verify_hash_signature(
+        &self,
+        provider: ProviderID,
+        key_name: String,
+        hash: Vec<u8>,
+        sign_algorithm: AsymmetricSignature,
+        signature: Vec<u8>,
+    ) -> Result<()> {
+        let op = PsaVerifyHash {
+            key_name,
+            alg: sign_algorithm,
+            hash,
+            signature,
+        };
+
+        let _ = self.op_handler.process_operation(
+            NativeOperation::PsaVerifyHash(op),
+            provider,
+            &self.auth_data,
+        )?;
+
+        Ok(())
+    }
+}

--- a/src/core/operation_handler.rs
+++ b/src/core/operation_handler.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2020, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![allow(dead_code)]
+
+use super::request_handler::RequestHandler;
+use crate::auth::AuthenticationData;
+use derivative::Derivative;
+use parsec_interface::operations::{Convert, NativeOperation, NativeResult};
+use parsec_interface::operations_protobuf::ProtobufConverter;
+use parsec_interface::requests::{
+    request::RequestHeader, BodyType, ProviderID, Request, Response, ResponseStatus, Result,
+};
+
+/// OperationHandler structure to send a `NativeOperation` and get a `NativeResult`.
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct OperationHandler {
+    #[derivative(Debug = "ignore")]
+    converter: Box<dyn Convert>,
+    version_maj: u8,
+    version_min: u8,
+    content_type: BodyType,
+    accept_type: BodyType,
+    request_client: RequestHandler,
+}
+
+#[allow(clippy::new_without_default)]
+impl OperationHandler {
+    /// Creates a OperationHandler instance. The request handler uses a timeout of 5 seconds on reads
+    /// and writes on the socket. It uses the version 1.0 to form request, the direct
+    /// authentication method and protobuf format as content type.
+    pub fn new() -> OperationHandler {
+        Default::default()
+    }
+
+    fn operation_to_request(
+        &self,
+        operation: NativeOperation,
+        provider: ProviderID,
+        auth: &AuthenticationData,
+    ) -> Result<Request> {
+        let opcode = operation.opcode();
+        let body = self.converter.operation_to_body(operation)?;
+        let header = RequestHeader {
+            version_maj: self.version_maj,
+            version_min: self.version_min,
+            provider,
+            session: 0, // no provisioning of sessions yet
+            content_type: self.content_type,
+            accept_type: self.accept_type,
+            auth_type: auth.auth_type(),
+            opcode,
+        };
+
+        Ok(Request {
+            header,
+            body,
+            auth: auth.into(),
+        })
+    }
+
+    fn response_to_result(&self, response: Response) -> Result<NativeResult> {
+        let status = response.header.status;
+        if status != ResponseStatus::Success {
+            return Err(status);
+        }
+        let opcode = response.header.opcode;
+        self.converter.body_to_result(response.body, opcode)
+    }
+
+    /// Send an operation to a specific provider and get a result.
+    ///
+    /// # Errors
+    ///
+    /// If the conversions between operation to request or between response to result fail, returns
+    /// a serializing or deserializing error. Returns an error if the operation itself failed.
+    pub fn process_operation(
+        &self,
+        operation: NativeOperation,
+        provider: ProviderID,
+        auth: &AuthenticationData,
+    ) -> Result<NativeResult> {
+        let request = self.operation_to_request(operation, provider, auth)?;
+
+        let response = self.request_client.process_request(request)?;
+        self.response_to_result(response)
+    }
+}
+
+impl Default for OperationHandler {
+    fn default() -> Self {
+        OperationHandler {
+            converter: Box::from(ProtobufConverter {}),
+            version_maj: 1,
+            version_min: 0,
+            content_type: BodyType::Protobuf,
+            accept_type: BodyType::Protobuf,
+            request_client: Default::default(),
+        }
+    }
+}

--- a/src/core/request_handler.rs
+++ b/src/core/request_handler.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2020, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![allow(dead_code)]
+
+use parsec_interface::requests::{Request, Response, Result};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::time::Duration;
+
+const DEFAULT_MAX_BODY_SIZE: usize = 1 << 31;
+const DEFAULT_SOCKET_PATH: &str = "/tmp/security-daemon-socket";
+
+/// Low level client structure to send a `Request` and get a `Response`.
+#[derive(Clone, Debug)]
+pub struct RequestHandler {
+    pub max_body_size: usize,
+    pub timeout: Option<Duration>,
+    pub socket_path: PathBuf,
+}
+
+impl RequestHandler {
+    /// Send a request and get a response.
+    pub fn process_request(&self, request: Request) -> Result<Response> {
+        // Try to connect once, wait for a timeout until trying again.
+        let mut stream = UnixStream::connect(&self.socket_path)?;
+
+        stream.set_read_timeout(self.timeout)?;
+        stream.set_write_timeout(self.timeout)?;
+
+        request.write_to_stream(&mut stream)?;
+        Response::read_from_stream(&mut stream, self.max_body_size)
+    }
+}
+
+impl Default for RequestHandler {
+    fn default() -> Self {
+        RequestHandler {
+            max_body_size: DEFAULT_MAX_BODY_SIZE,
+            timeout: None,
+            socket_path: DEFAULT_SOCKET_PATH.into(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2020, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Client library for integration with the Parsec service
+#![deny(
+    nonstandard_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    private_in_public,
+    unconditional_recursion,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true,
+    missing_debug_implementations,
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results,
+    missing_copy_implementations
+)]
+// This one is hard to avoid.
+#![allow(clippy::multiple_crate_versions)]
+
+pub mod auth;
+mod core;
+
+pub use crate::core::CoreClient;

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2020, Arm Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Continuous Integration test script, executed by GitHub Actions on x86 and
+# Travis CI on Arm64.
+
+set -euf -o pipefail
+
+################
+# Build client #
+################
+RUST_BACKTRACE=1 cargo build
+
+#################
+# Static checks #
+#################
+# On native target clippy or fmt might not be available.
+if cargo fmt -h; then
+	cargo fmt --all -- --check
+fi
+if cargo clippy -h; then
+	cargo clippy --all-targets -- -D clippy::all -D clippy::cargo
+fi


### PR DESCRIPTION
This commit adds the initial version of the Parsec Rust client.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>

This version of the client is *not* finished and requires a lot of changes for it to be usable/production-ready. Some of the things that are not done well and will be improved are:
* documentation is minimal and needs to be expanded
* tests should be implemented, either with a "mock service" or with the real Parsec service
* there are still unsafe uses of `unwrap`, `expect` ...
* there is no configuration of the parameters used
* the API of the client was not designed to match any existing "ergonomic design" crypto APIs from the Rust ecosystem
* potentially others - if you find this kind of issues that are more structural than syntactic/aesthetic, please add a [FYI] comment and raise an issue for later fixing

Recommended review order: 
* all the markdown/legal files
* `src/core/request_handler.rs`
* `src/core/mod.rs`
* `src/auth.rs`
* `src/lib.rs`
* CI-related files