### PR TITLE
Make inner attributes configurable

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -54,6 +54,11 @@ impl CoreClient {
         }
     }
 
+    /// Update the authentication data of the client
+    pub fn set_auth_data(&mut self, auth_data: AuthenticationData) {
+        self.auth_data = auth_data;
+    }
+
     /// list opcodes
     pub fn list_provider_operations(&self, provider: ProviderID) -> Result<HashSet<Opcode>> {
         let res = self.op_handler.process_operation(

--- a/src/core/request_handler.rs
+++ b/src/core/request_handler.rs
@@ -60,3 +60,22 @@ impl Default for RequestHandler {
         }
     }
 }
+
+impl crate::CoreClient {
+    /// Set the maximum body size allowed for requests
+    pub fn set_max_body_size(&mut self, max_body_size: usize) {
+        self.op_handler.request_handler.max_body_size = max_body_size;
+    }
+
+    /// Set the timeout allowed for operations on the IPC used for communicating with the service.
+    ///
+    /// A value of `None` represents "no timeout"
+    pub fn set_ipc_timeout(&mut self, timeout: Option<Duration>) {
+        self.op_handler.request_handler.timeout = timeout;
+    }
+
+    /// Set the location of the Unix Socket path where the service socket can be found
+    pub fn set_socket_path(&mut self, socket_path: PathBuf) {
+        self.op_handler.request_handler.socket_path = socket_path;
+    }
+}


### PR DESCRIPTION
This commit makes the attributes within the request and operation
handlers configurable through the `CoreClient`.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>

fixes #3 