### PR TITLE
Add testing framework and unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ num = "0.2.1"
 rand = "0.7.3"
 log = "0.4.8"
 derivative = "2.0.2"
+
+[dev-dependencies]
+mockstream = "0.0.3"
+uuid = "0.7.4"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This project uses the following third party crates:
 * rand (Apache-2.0)
 * log (Apache-2.0)
 * derivative (MIT and Apache-2.0)
+* mockstream (MIT)
+* uuid (MIT and Apache-2.0)
 
 ## Contributing
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -82,14 +82,20 @@ impl CoreClient {
     }
 
     /// ping
-    pub fn ping(&self) -> Result<()> {
-        let _ = self.op_handler.process_operation(
+    pub fn ping(&self) -> Result<(u8, u8)> {
+        let res = self.op_handler.process_operation(
             NativeOperation::Ping(Ping {}),
             ProviderID::Core,
             &AuthenticationData::None,
         )?;
 
-        Ok(())
+        if let NativeResult::Ping(res) = res {
+            Ok((res.wire_protocol_version_maj, res.wire_protocol_version_min))
+        } else {
+            // Should really not be reached given the checks we do, but it's not impossible if some
+            // changes happen in the interface
+            Err(Error::Client(ClientErrorKind::InvalidServiceResponseType))
+        }
     }
 
     /// generate key

--- a/src/core/operation_handler.rs
+++ b/src/core/operation_handler.rs
@@ -22,6 +22,7 @@ pub struct OperationHandler {
     pub wire_protocol_version_min: u8,
     pub content_type: BodyType,
     pub accept_type: BodyType,
+    #[cfg_attr(test, derivative(Debug = "ignore"))]
     pub request_handler: RequestHandler,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 use parsec_interface::requests::ResponseStatus;
 
 /// Enum used to denote errors returned to the library user
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// Errors originating in the service
     Service(ResponseStatus),
@@ -26,6 +26,34 @@ pub enum ClientErrorKind {
 impl From<ClientErrorKind> for Error {
     fn from(client_error: ClientErrorKind) -> Self {
         Error::Client(client_error)
+    }
+}
+
+impl PartialEq for ClientErrorKind {
+    fn eq(&self, other: &Self) -> bool {
+        match self {
+            ClientErrorKind::Interface(status) => {
+                if let ClientErrorKind::Interface(other_status) = other {
+                    other_status == status
+                } else {
+                    false
+                }
+            }
+            ClientErrorKind::Ipc(error) => {
+                if let ClientErrorKind::Ipc(other_error) = other {
+                    other_error.kind() == error.kind()
+                } else {
+                    false
+                }
+            }
+            ClientErrorKind::InvalidServiceResponseType => {
+                if let ClientErrorKind::InvalidServiceResponseType = other {
+                    true
+                } else {
+                    false
+                }
+            }
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,5 +34,6 @@
 pub mod auth;
 mod core;
 pub mod error;
+mod tests;
 
 pub use crate::core::CoreClient;

--- a/src/tests/core_tests.rs
+++ b/src/tests/core_tests.rs
@@ -1,0 +1,418 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::error::{ClientErrorKind, Error};
+use crate::{auth::AuthenticationData, CoreClient};
+use mockstream::MockStream;
+use parsec_interface::operations;
+use parsec_interface::operations::list_providers::ProviderInfo;
+use parsec_interface::operations::psa_algorithm::*;
+use parsec_interface::operations::psa_key_attributes::*;
+use parsec_interface::operations::Convert;
+use parsec_interface::operations::{NativeOperation, NativeResult};
+use parsec_interface::operations_protobuf::ProtobufConverter;
+use parsec_interface::requests::Response;
+use parsec_interface::requests::ResponseStatus;
+use parsec_interface::requests::{request::RequestHeader, Request};
+use parsec_interface::requests::{AuthType, BodyType, Opcode, ProviderID};
+use std::collections::HashSet;
+
+const PROTOBUF_CONVERTER: ProtobufConverter = ProtobufConverter {};
+const REQ_HEADER: RequestHeader = RequestHeader {
+    version_maj: 1,
+    version_min: 0,
+    provider: ProviderID::Core,
+    session: 0,
+    content_type: BodyType::Protobuf,
+    accept_type: BodyType::Protobuf,
+    auth_type: AuthType::NoAuth,
+    opcode: Opcode::Ping,
+};
+const APP_NAME: &str = "test-app";
+
+fn get_response_bytes_from_result(result: NativeResult) -> Vec<u8> {
+    let mut stream = MockStream::new();
+    let mut req_hdr = REQ_HEADER;
+    req_hdr.opcode = result.opcode();
+    let mut resp = Response::from_request_header(req_hdr, ResponseStatus::Success);
+    resp.body = PROTOBUF_CONVERTER.result_to_body(result).unwrap();
+    resp.write_to_stream(&mut stream).unwrap();
+    stream.pop_bytes_written()
+}
+
+fn get_req_from_bytes(bytes: Vec<u8>) -> Request {
+    let mut stream = MockStream::new();
+    stream.push_bytes_to_read(&bytes);
+    Request::read_from_stream(&mut stream, usize::max_value()).unwrap()
+}
+
+fn get_operation_from_req_bytes(bytes: Vec<u8>) -> NativeOperation {
+    let req = get_req_from_bytes(bytes);
+    PROTOBUF_CONVERTER
+        .body_to_operation(req.body, req.header.opcode)
+        .unwrap()
+}
+
+fn get_client() -> CoreClient {
+    CoreClient::new(AuthenticationData::AppIdentity(String::from(APP_NAME)))
+}
+
+#[test]
+fn ping_test() {
+    let mut client = get_client();
+    client.set_mock_read(&get_response_bytes_from_result(NativeResult::Ping(
+        operations::ping::Result {
+            wire_protocol_version_maj: 1,
+            wire_protocol_version_min: 0,
+        },
+    )));
+    // Check request:
+    // Ping request is empty so no checking to be done
+
+    // Check response:
+    assert_eq!(client.ping().expect("Ping failed"), (1, 0));
+}
+
+#[test]
+fn list_provider_test() {
+    let mut client = get_client();
+    let mut provider_info = Vec::new();
+    provider_info.push(ProviderInfo {
+        uuid: uuid::Uuid::nil(),
+        description: String::from("Some empty provider"),
+        vendor: String::from("Arm Ltd."),
+        version_maj: 1,
+        version_min: 0,
+        version_rev: 0,
+        id: ProviderID::Core,
+    });
+    client.set_mock_read(&get_response_bytes_from_result(
+        NativeResult::ListProviders(operations::list_providers::Result {
+            providers: provider_info,
+        }),
+    ));
+    let providers = client.list_providers().expect("Failed to list providers");
+    // Check request:
+    // ListProviders request is empty so no checking to be done
+
+    // Check response:
+    assert_eq!(providers.len(), 1);
+    assert_eq!(providers[0].uuid, uuid::Uuid::nil());
+}
+
+#[test]
+fn list_provider_operations_test() {
+    let mut client = get_client();
+    let mut opcodes = HashSet::new();
+    let _ = opcodes.insert(Opcode::PsaDestroyKey);
+    let _ = opcodes.insert(Opcode::PsaGenerateKey);
+    client.set_mock_read(&get_response_bytes_from_result(NativeResult::ListOpcodes(
+        operations::list_opcodes::Result { opcodes },
+    )));
+    let opcodes = client
+        .list_provider_operations(ProviderID::MbedCrypto)
+        .expect("Failed to retrieve opcodes");
+    // Check request:
+    // ListOpcodes request is empty so no checking to be done
+
+    // Check response:
+    assert_eq!(opcodes.len(), 2);
+    assert!(opcodes.contains(&Opcode::PsaGenerateKey) && opcodes.contains(&Opcode::PsaDestroyKey));
+}
+
+#[test]
+fn generate_key_test() {
+    let mut client = get_client();
+    client.set_mock_read(&get_response_bytes_from_result(
+        NativeResult::PsaGenerateKey(operations::psa_generate_key::Result {}),
+    ));
+    let key_name = String::from("key-name");
+    let key_attrs = KeyAttributes {
+        key_type: KeyType::Aes,
+        key_bits: 192,
+        key_policy: KeyPolicy {
+            key_usage_flags: UsageFlags {
+                export: true,
+                copy: true,
+                cache: true,
+                encrypt: false,
+                decrypt: true,
+                sign_message: false,
+                verify_message: false,
+                sign_hash: false,
+                verify_hash: false,
+                derive: false,
+            },
+            key_algorithm: Algorithm::Cipher(Cipher::Ctr),
+        },
+    };
+
+    client
+        .generate_key(ProviderID::Tpm, key_name.clone(), key_attrs.clone())
+        .expect("failed to generate key");
+
+    // Check request:
+    let op = get_operation_from_req_bytes(client.get_mock_write());
+    if let NativeOperation::PsaGenerateKey(op) = op {
+        assert_eq!(op.attributes, key_attrs);
+        assert_eq!(op.key_name, key_name);
+    } else {
+        panic!("Got wrong operation type: {:?}", op);
+    }
+
+    // Check response:
+    // GenerateKey response is empty so no checking to be done
+}
+
+#[test]
+fn destroy_key_test() {
+    let mut client = get_client();
+    client.set_mock_read(&get_response_bytes_from_result(
+        NativeResult::PsaDestroyKey(operations::psa_destroy_key::Result {}),
+    ));
+    let key_name = String::from("key-name");
+    client
+        .destroy_key(ProviderID::Pkcs11, key_name.clone())
+        .expect("Failed to call destroy key");
+
+    // Check request:
+    let op = get_operation_from_req_bytes(client.get_mock_write());
+    if let NativeOperation::PsaDestroyKey(op) = op {
+        assert_eq!(op.key_name, key_name);
+    } else {
+        panic!("Got wrong operation type: {:?}", op);
+    }
+
+    // Check response:
+    // DestroyKey response is empty so no checking to be done
+}
+
+#[test]
+fn import_key_test() {
+    let mut client = get_client();
+    client.set_mock_read(&get_response_bytes_from_result(NativeResult::PsaImportKey(
+        operations::psa_import_key::Result {},
+    )));
+    let key_name = String::from("key-name");
+    let key_attrs = KeyAttributes {
+        key_type: KeyType::Aes,
+        key_bits: 192,
+        key_policy: KeyPolicy {
+            key_usage_flags: UsageFlags {
+                export: true,
+                copy: true,
+                cache: true,
+                encrypt: false,
+                decrypt: true,
+                sign_message: false,
+                verify_message: false,
+                sign_hash: false,
+                verify_hash: false,
+                derive: false,
+            },
+            key_algorithm: Algorithm::Cipher(Cipher::Ctr),
+        },
+    };
+    let key_data = vec![0xff_u8; 128];
+    client
+        .import_key(
+            ProviderID::Pkcs11,
+            key_name.clone(),
+            key_data.clone(),
+            key_attrs.clone(),
+        )
+        .unwrap();
+
+    // Check request:
+    let op = get_operation_from_req_bytes(client.get_mock_write());
+    if let NativeOperation::PsaImportKey(op) = op {
+        assert_eq!(op.attributes, key_attrs);
+        assert_eq!(op.key_name, key_name);
+        assert_eq!(op.data, key_data);
+    } else {
+        panic!("Got wrong operation type: {:?}", op);
+    }
+
+    // Check response:
+    // ImportKey response is empty so no checking to be done
+}
+
+#[test]
+fn export_public_key_test() {
+    let mut client = get_client();
+    let key_data = vec![0xa5; 128];
+    client.set_mock_read(&get_response_bytes_from_result(
+        NativeResult::PsaExportPublicKey(operations::psa_export_public_key::Result {
+            data: key_data.clone(),
+        }),
+    ));
+
+    let key_name = String::from("key-name");
+    // Check response:
+    assert_eq!(
+        client
+            .export_public_key(ProviderID::MbedCrypto, key_name.clone())
+            .expect("Failed to export public key"),
+        key_data
+    );
+
+    // Check request:
+    let op = get_operation_from_req_bytes(client.get_mock_write());
+    if let NativeOperation::PsaExportPublicKey(op) = op {
+        assert_eq!(op.key_name, key_name);
+    } else {
+        panic!("Got wrong operation type: {:?}", op);
+    }
+}
+
+#[test]
+fn sign_hash_test() {
+    let mut client = get_client();
+    let hash = vec![0x77_u8; 32];
+    let key_name = String::from("key_name");
+    let sign_algorithm = AsymmetricSignature::Ecdsa {
+        hash_alg: Hash::Sha256,
+    };
+    let signature = vec![0x33_u8; 128];
+    client.set_mock_read(&get_response_bytes_from_result(NativeResult::PsaSignHash(
+        operations::psa_sign_hash::Result {
+            signature: signature.clone(),
+        },
+    )));
+
+    // Check response:
+    assert_eq!(
+        client
+            .sign_hash(
+                ProviderID::MbedCrypto,
+                key_name.clone(),
+                hash.clone(),
+                sign_algorithm.clone()
+            )
+            .expect("Failed to sign hash"),
+        signature
+    );
+
+    // Check request:
+    let op = get_operation_from_req_bytes(client.get_mock_write());
+    if let NativeOperation::PsaSignHash(op) = op {
+        assert_eq!(op.key_name, key_name);
+        assert_eq!(op.hash, hash);
+        assert_eq!(op.alg, sign_algorithm);
+    } else {
+        panic!("Got wrong operation type: {:?}", op);
+    }
+}
+
+#[test]
+fn verify_hash_test() {
+    let mut client = get_client();
+    let hash = vec![0x77_u8; 32];
+    let key_name = String::from("key_name");
+    let sign_algorithm = AsymmetricSignature::Ecdsa {
+        hash_alg: Hash::Sha256,
+    };
+    let signature = vec![0x33_u8; 128];
+    client.set_mock_read(&get_response_bytes_from_result(
+        NativeResult::PsaVerifyHash(operations::psa_verify_hash::Result {}),
+    ));
+
+    client
+        .verify_hash_signature(
+            ProviderID::MbedCrypto,
+            key_name.clone(),
+            hash.clone(),
+            sign_algorithm.clone(),
+            signature.clone(),
+        )
+        .expect("Failed to sign hash");
+
+    // Check request:
+    let op = get_operation_from_req_bytes(client.get_mock_write());
+    if let NativeOperation::PsaVerifyHash(op) = op {
+        assert_eq!(op.key_name, key_name);
+        assert_eq!(op.hash, hash);
+        assert_eq!(op.alg, sign_algorithm);
+        assert_eq!(op.signature, signature);
+    } else {
+        panic!("Got wrong operation type: {:?}", op);
+    }
+
+    // Check response:
+    // VerifyHash response is empty so no checking to be done
+}
+
+#[test]
+fn different_response_type_test() {
+    let mut client = get_client();
+    client.set_mock_read(&get_response_bytes_from_result(
+        NativeResult::PsaVerifyHash(operations::psa_verify_hash::Result {}),
+    ));
+    let key_name = String::from("key-name");
+    let err = client
+        .destroy_key(ProviderID::Pkcs11, key_name)
+        .expect_err("Error was expected");
+
+    assert_eq!(
+        err,
+        Error::Client(ClientErrorKind::InvalidServiceResponseType)
+    );
+}
+
+#[test]
+fn response_status_test() {
+    let mut client = get_client();
+    let mut stream = MockStream::new();
+    let status = ResponseStatus::PsaErrorDataCorrupt;
+    let mut resp = Response::from_request_header(REQ_HEADER, ResponseStatus::Success);
+    resp.header.status = status;
+    resp.write_to_stream(&mut stream).unwrap();
+    client.set_mock_read(&stream.pop_bytes_written());
+    let err = client.ping().expect_err("Error was expected");
+
+    assert_eq!(err, Error::Service(status));
+}
+
+#[test]
+fn malformed_response_test() {
+    let mut client = get_client();
+    client.set_mock_read(&[0xcb_u8; 130]);
+    let err = client.ping().expect_err("Error was expected");
+
+    assert_eq!(
+        err,
+        Error::Client(ClientErrorKind::Interface(ResponseStatus::InvalidHeader))
+    );
+}
+
+#[test]
+fn request_fields_test() {
+    let mut client = get_client();
+    client.set_mock_read(&get_response_bytes_from_result(NativeResult::Ping(
+        operations::ping::Result {
+            wire_protocol_version_maj: 1,
+            wire_protocol_version_min: 0,
+        },
+    )));
+    let _ = client.ping().expect("Ping failed");
+
+    let req = get_req_from_bytes(client.get_mock_write());
+    assert_eq!(req.header, REQ_HEADER);
+}
+
+#[test]
+fn auth_value_test() {
+    let mut client = get_client();
+    client.set_mock_read(&get_response_bytes_from_result(
+        NativeResult::PsaDestroyKey(operations::psa_destroy_key::Result {}),
+    ));
+    let key_name = String::from("key-name");
+    client
+        .destroy_key(ProviderID::Pkcs11, key_name)
+        .expect("Failed to call destroy key");
+
+    let req = get_req_from_bytes(client.get_mock_write());
+    assert_eq!(
+        String::from_utf8(req.auth.bytes().to_owned()).unwrap(),
+        String::from(APP_NAME)
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+#![cfg(test)]
+
+mod core_tests;

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -23,3 +23,8 @@ fi
 if cargo clippy -h; then
 	cargo clippy --all-targets -- -D clippy::all -D clippy::cargo
 fi
+
+#############
+# Run tests #
+#############
+RUST_BACKTRACE=1 cargo test


### PR DESCRIPTION
This commit creates the testing framework used to verify the client
library. It also adds unit tests for the operations implemented thus
far.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>

Will add more unit tests, this is just to verify the general soundness of the plan.