### PR TITLE
Add "psa_" prefix to method names.

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -180,7 +180,7 @@ impl Provider {
 ///};
 ///
 ///client
-///    .generate_key(desired_provider, key_name, key_attrs)
+///    .psa_generate_key(desired_provider, key_name, key_attrs)
 ///    .expect("Failed to create key!");
 ///```
 ///
@@ -281,7 +281,7 @@ impl CoreClient {
     ///
     /// See the operation-specific response codes returned by the service
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_generate_key.html#specific-response-status-codes).
-    pub fn generate_key(
+    pub fn psa_generate_key(
         &self,
         provider: Provider,
         key_name: String,
@@ -304,12 +304,12 @@ impl CoreClient {
     /// Destroy a key.
     ///
     /// Given that keys are namespaced at a provider level, it is
-    /// important to call `destroy_key` on the correct combination of
+    /// important to call `psa_destroy_key` on the correct combination of
     /// `provider` and `key_name`.
     ///
     /// See the operation-specific response codes returned by the service
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_destroy_key.html#specific-response-status-codes).
-    pub fn destroy_key(&self, provider: Provider, key_name: String) -> Result<()> {
+    pub fn psa_destroy_key(&self, provider: Provider, key_name: String) -> Result<()> {
         let op = PsaDestroyKey { key_name };
 
         let _ = self.op_handler.process_operation(
@@ -342,7 +342,7 @@ impl CoreClient {
     ///
     /// See the operation-specific response codes returned by the service
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_import_key.html#specific-response-status-codes).
-    pub fn import_key(
+    pub fn psa_import_key(
         &self,
         provider: Provider,
         key_name: String,
@@ -377,7 +377,7 @@ impl CoreClient {
     ///
     /// See the operation-specific response codes returned by the service
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_export_public_key.html#specific-response-status-codes).
-    pub fn export_public_key(&self, provider: Provider, key_name: String) -> Result<Vec<u8>> {
+    pub fn psa_export_public_key(&self, provider: Provider, key_name: String) -> Result<Vec<u8>> {
         let op = PsaExportPublicKey { key_name };
 
         let res = self.op_handler.process_operation(
@@ -409,7 +409,7 @@ impl CoreClient {
     ///
     /// See the operation-specific response codes returned by the service
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_sign_hash.html#specific-response-status-codes).
-    pub fn sign_hash(
+    pub fn psa_sign_hash(
         &self,
         provider: Provider,
         key_name: String,
@@ -451,7 +451,7 @@ impl CoreClient {
     ///
     /// See the operation-specific response codes returned by the service
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_verify_hash.html#specific-response-status-codes).
-    pub fn verify_hash_signature(
+    pub fn psa_verify_hash(
         &self,
         provider: Provider,
         key_name: String,

--- a/src/core/testing/core_tests.rs
+++ b/src/core/testing/core_tests.rs
@@ -117,7 +117,7 @@ fn list_provider_operations_test() {
 }
 
 #[test]
-fn generate_key_test() {
+fn psa_generate_key_test() {
     let mut client: TestCoreClient = Default::default();
     client.set_mock_read(&get_response_bytes_from_result(
         NativeResult::PsaGenerateKey(operations::psa_generate_key::Result {}),
@@ -144,7 +144,7 @@ fn generate_key_test() {
     };
 
     client
-        .generate_key(Provider::Tpm, key_name.clone(), key_attrs.clone())
+        .psa_generate_key(Provider::Tpm, key_name.clone(), key_attrs.clone())
         .expect("failed to generate key");
 
     // Check request:
@@ -161,14 +161,14 @@ fn generate_key_test() {
 }
 
 #[test]
-fn destroy_key_test() {
+fn psa_destroy_key_test() {
     let mut client: TestCoreClient = Default::default();
     client.set_mock_read(&get_response_bytes_from_result(
         NativeResult::PsaDestroyKey(operations::psa_destroy_key::Result {}),
     ));
     let key_name = String::from("key-name");
     client
-        .destroy_key(Provider::Pkcs11, key_name.clone())
+        .psa_destroy_key(Provider::Pkcs11, key_name.clone())
         .expect("Failed to call destroy key");
 
     // Check request:
@@ -184,7 +184,7 @@ fn destroy_key_test() {
 }
 
 #[test]
-fn import_key_test() {
+fn psa_import_key_test() {
     let mut client: TestCoreClient = Default::default();
     client.set_mock_read(&get_response_bytes_from_result(NativeResult::PsaImportKey(
         operations::psa_import_key::Result {},
@@ -211,7 +211,7 @@ fn import_key_test() {
     };
     let key_data = vec![0xff_u8; 128];
     client
-        .import_key(
+        .psa_import_key(
             Provider::Pkcs11,
             key_name.clone(),
             key_data.clone(),
@@ -234,7 +234,7 @@ fn import_key_test() {
 }
 
 #[test]
-fn export_public_key_test() {
+fn psa_export_public_key_test() {
     let mut client: TestCoreClient = Default::default();
     let key_data = vec![0xa5; 128];
     client.set_mock_read(&get_response_bytes_from_result(
@@ -247,7 +247,7 @@ fn export_public_key_test() {
     // Check response:
     assert_eq!(
         client
-            .export_public_key(Provider::MbedCrypto, key_name.clone())
+            .psa_export_public_key(Provider::MbedCrypto, key_name.clone())
             .expect("Failed to export public key"),
         key_data
     );
@@ -262,7 +262,7 @@ fn export_public_key_test() {
 }
 
 #[test]
-fn sign_hash_test() {
+fn psa_sign_hash_test() {
     let mut client: TestCoreClient = Default::default();
     let hash = vec![0x77_u8; 32];
     let key_name = String::from("key_name");
@@ -279,7 +279,7 @@ fn sign_hash_test() {
     // Check response:
     assert_eq!(
         client
-            .sign_hash(
+            .psa_sign_hash(
                 Provider::MbedCrypto,
                 key_name.clone(),
                 hash.clone(),
@@ -314,7 +314,7 @@ fn verify_hash_test() {
     ));
 
     client
-        .verify_hash_signature(
+        .psa_verify_hash(
             Provider::MbedCrypto,
             key_name.clone(),
             hash.clone(),
@@ -346,7 +346,7 @@ fn different_response_type_test() {
     ));
     let key_name = String::from("key-name");
     let err = client
-        .destroy_key(Provider::Pkcs11, key_name)
+        .psa_destroy_key(Provider::Pkcs11, key_name)
         .expect_err("Error was expected");
 
     assert_eq!(
@@ -404,7 +404,7 @@ fn auth_value_test() {
     ));
     let key_name = String::from("key-name");
     client
-        .destroy_key(Provider::Pkcs11, key_name)
+        .psa_destroy_key(Provider::Pkcs11, key_name)
         .expect("Failed to call destroy key");
 
     let req = get_req_from_bytes(client.get_mock_write());


### PR DESCRIPTION
This commit adds the "psa_" prefix to PSA-related methods on the
CoreClient. This makes it more clear that these are direct mappings to
the operations represented in the IPC contract.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>