### PR TITLE
Make `implicit_provider` optional

### DIFF
--- a/src/core/testing/mod.rs
+++ b/src/core/testing/mod.rs
@@ -61,12 +61,13 @@ impl DerefMut for TestBasicClient {
 impl Default for TestBasicClient {
     fn default() -> Self {
         let mut client = TestBasicClient {
-            core_client: BasicClient::new(
-                AuthenticationData::AppIdentity(String::from(DEFAULT_APP_NAME)),
-                ProviderID::Pkcs11,
-            ),
+            core_client: BasicClient::new(AuthenticationData::AppIdentity(String::from(
+                DEFAULT_APP_NAME,
+            ))),
             mock_stream: SyncMockStream::new(),
         };
+
+        client.core_client.set_implicit_provider(ProviderID::Pkcs11);
 
         client
             .core_client

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,8 @@ pub enum ClientErrorKind {
     InvalidServiceResponseType,
     /// The operation is not supported by the selected provider
     InvalidProvider,
+    /// Client is missing an implicit provider
+    NoProvider,
 }
 
 impl From<ClientErrorKind> for Error {
@@ -57,6 +59,13 @@ impl PartialEq for ClientErrorKind {
             }
             ClientErrorKind::InvalidProvider => {
                 if let ClientErrorKind::InvalidProvider = other {
+                    true
+                } else {
+                    false
+                }
+            }
+            ClientErrorKind::NoProvider => {
+                if let ClientErrorKind::NoProvider = other {
                     true
                 } else {
                     false


### PR DESCRIPTION
This commit makes the `implicit_provider` optional, allowing the
`BasicClient` to start with no such provider. When in this state, core
operations are allowed but crypto operations will fail with
`NoProvider`.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>