### PR TITLE
Add methods for modifying timeout of IPC handlers

### DIFF
--- a/src/core/ipc_handler/mod.rs
+++ b/src/core/ipc_handler/mod.rs
@@ -3,6 +3,7 @@
 //! Types implementing an abstraction over IPC channels
 use crate::error::Result;
 use std::io::{Read, Write};
+use std::time::Duration;
 
 pub mod unix_socket;
 
@@ -18,4 +19,7 @@ impl<T: Read + Write> ReadWrite for T {}
 pub trait Connect {
     /// Connect to underlying IPC and return a readable and writeable stream
     fn connect(&self) -> Result<Box<dyn ReadWrite>>;
+
+    /// Set timeout for all produced streams.
+    fn set_timeout(&mut self, timeout: Option<Duration>);
 }

--- a/src/core/ipc_handler/unix_socket.rs
+++ b/src/core/ipc_handler/unix_socket.rs
@@ -32,6 +32,10 @@ impl Connect for Handler {
 
         Ok(Box::from(stream))
     }
+
+    fn set_timeout(&mut self, timeout: Option<Duration>) {
+        self.timeout = timeout;
+    }
 }
 
 impl Handler {

--- a/src/core/request_client.rs
+++ b/src/core/request_client.rs
@@ -5,6 +5,7 @@ use super::ipc_handler::{unix_socket, Connect};
 use crate::error::{ClientErrorKind, Result};
 use derivative::Derivative;
 use parsec_interface::requests::{Request, Response};
+use std::time::Duration;
 
 const DEFAULT_MAX_BODY_SIZE: usize = usize::max_value();
 
@@ -64,5 +65,15 @@ impl crate::BasicClient {
     /// By default the [Unix domain socket client](../ipc_handler/unix_socket/struct.Client.html) is used.
     pub fn set_ipc_handler(&mut self, ipc_handler: Box<dyn Connect>) {
         self.op_client.request_client.ipc_handler = ipc_handler;
+    }
+
+    /// Set the timeout for operations on the IPC stream.
+    ///
+    /// The value defaults to 1 second.
+    pub fn set_timeout(&mut self, timeout: Option<Duration>) {
+        self.op_client
+            .request_client
+            .ipc_handler
+            .set_timeout(timeout);
     }
 }

--- a/src/core/testing/mod.rs
+++ b/src/core/testing/mod.rs
@@ -8,6 +8,7 @@ use crate::error::Result;
 use mockstream::{FailingMockStream, SyncMockStream};
 use parsec_interface::requests::ProviderID;
 use std::ops::{Deref, DerefMut};
+use std::time::Duration;
 
 mod core_tests;
 
@@ -19,6 +20,8 @@ impl Connect for MockIpc {
     fn connect(&self) -> Result<Box<dyn ReadWrite>> {
         Ok(Box::from(self.0.clone()))
     }
+
+    fn set_timeout(&mut self, _timeout: Option<Duration>) {}
 }
 
 struct FailingMockIpc(FailingMockStream);
@@ -27,6 +30,8 @@ impl Connect for FailingMockIpc {
     fn connect(&self) -> Result<Box<dyn ReadWrite>> {
         Ok(Box::from(self.0.clone()))
     }
+
+    fn set_timeout(&mut self, _timeout: Option<Duration>) {}
 }
 
 struct TestBasicClient {


### PR DESCRIPTION
This commit adds functionality to the `BasicClient` to update the
timeout of IPC handlers in flight.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>