### PR TITLE
Resurface full interface as part of core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,15 @@ categories = ["development-tools"]
 edition = "2018"
 
 [dependencies]
-parsec-interface = "0.13.0"
+parsec-interface = "0.14.0"
 num = "0.2.1"
 rand = "0.7.3"
 log = "0.4.8"
-derivative = "2.1.0"
+derivative = "2.1.1"
 uuid = "0.7.4"
 
 [dev-dependencies]
 mockstream = "0.0.3"
+
+[features]
+testing = ["parsec-interface/testing"]

--- a/src/core/basic_client.rs
+++ b/src/core/basic_client.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Basic client for Parsec integration
 use super::operation_client::OperationClient;
-use super::{Opcode, ProviderID};
 use crate::auth::AuthenticationData;
 use crate::error::{ClientErrorKind, Error, Result};
 use parsec_interface::operations::list_opcodes::Operation as ListOpcodes;
@@ -17,6 +16,7 @@ use parsec_interface::operations::psa_key_attributes::KeyAttributes;
 use parsec_interface::operations::psa_sign_hash::Operation as PsaSignHash;
 use parsec_interface::operations::psa_verify_hash::Operation as PsaVerifyHash;
 use parsec_interface::operations::{NativeOperation, NativeResult};
+use parsec_interface::requests::{Opcode, ProviderID};
 use std::collections::HashSet;
 
 /// Core client for Parsec service
@@ -49,7 +49,7 @@ use std::collections::HashSet;
 ///```no_run
 ///# use parsec_client::auth::AuthenticationData;
 ///# use parsec_client::BasicClient;
-///# use parsec_client::core::ProviderID;
+///# use parsec_client::core::interface::requests::ProviderID;
 ///# let client: BasicClient = BasicClient::new(AuthenticationData::AppIdentity(String::from("app-name")));
 ///let res = client.ping();
 ///
@@ -71,7 +71,7 @@ use std::collections::HashSet;
 ///```no_run
 ///# use parsec_client::auth::AuthenticationData;
 ///# use parsec_client::BasicClient;
-///# use parsec_client::core::ProviderID;
+///# use parsec_client::core::interface::requests::ProviderID;
 ///# let client: BasicClient = BasicClient::new(AuthenticationData::AppIdentity(String::from("app-name")));
 ///use uuid::Uuid;
 ///
@@ -93,9 +93,9 @@ use std::collections::HashSet;
 ///```no_run
 ///# use parsec_client::auth::AuthenticationData;
 ///# use parsec_client::BasicClient;
-///# use parsec_client::core::ProviderID;
+///# use parsec_client::core::interface::requests::ProviderID;
 ///# let mut client: BasicClient = BasicClient::new(AuthenticationData::AppIdentity(String::from("app-name")));
-///use parsec_client::core::Opcode;
+///use parsec_client::core::interface::requests::Opcode;
 ///
 ///let desired_provider = ProviderID::Pkcs11;
 ///let provider_opcodes = client
@@ -114,10 +114,10 @@ use std::collections::HashSet;
 ///```no_run
 ///# use parsec_client::auth::AuthenticationData;
 ///# use parsec_client::BasicClient;
-///# use parsec_client::core::ProviderID;
+///# use parsec_client::core::interface::requests::ProviderID;
 ///# let client: BasicClient = BasicClient::new(AuthenticationData::AppIdentity(String::from("app-name")));
-///use parsec_client::core::psa_algorithm::{Algorithm, AsymmetricSignature, Hash};
-///use parsec_client::core::psa_key_attributes::{KeyAttributes, KeyPolicy, KeyType, UsageFlags};
+///use parsec_client::core::interface::operations::psa_algorithm::{Algorithm, AsymmetricSignature, Hash};
+///use parsec_client::core::interface::operations::psa_key_attributes::{KeyAttributes, KeyPolicy, KeyType, UsageFlags};
 ///
 ///let key_name = String::from("rusty key 🔑");
 ///// This algorithm identifier will be used within the key policy (i.e. what

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,12 +1,15 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 //! Core helpers for integration with the Parsec service
+//!
+//! The `interface` module is a version of the [`parsec-interface`](https://crates.io/crates/parsec-interface)
+//! crate and is meant to be used in conjuction with the [basic](basic_client/struct.BasicClient.html),
+//! [operation](operation_client/struct.OperationClient.html) and [request](request_client/struct.RequestClient.html)
+//! structures.
 pub mod basic_client;
 pub mod ipc_handler;
 pub mod operation_client;
 pub mod request_client;
 mod testing;
 
-pub use parsec_interface::operations::{psa_algorithm, psa_key_attributes};
-pub use parsec_interface::operations_protobuf::ProtobufConverter;
-pub use parsec_interface::requests::{Opcode, ProviderID};
+pub use parsec_interface as interface;

--- a/src/core/testing/core_tests.rs
+++ b/src/core/testing/core_tests.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::{FailingMockIpc, TestBasicClient, DEFAULT_APP_NAME};
 use crate::auth::AuthenticationData;
-use crate::core::ProviderID;
 use crate::error::{ClientErrorKind, Error};
 use crate::BasicClient;
 use mockstream::{FailingMockStream, MockStream};
@@ -13,6 +12,7 @@ use parsec_interface::operations::psa_key_attributes::*;
 use parsec_interface::operations::Convert;
 use parsec_interface::operations::{NativeOperation, NativeResult};
 use parsec_interface::operations_protobuf::ProtobufConverter;
+use parsec_interface::requests::ProviderID;
 use parsec_interface::requests::Response;
 use parsec_interface::requests::ResponseStatus;
 use parsec_interface::requests::{request::RequestHeader, Request};


### PR DESCRIPTION
This commit updates the `core` module to resurface the whole parsec
interface, making it easier for clients to access the same version of
the interface as used in the client internals.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>