### PR TITLE
Add Send and Sync to trait objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["parsec"]
 categories = ["development-tools"]
 edition = "2018"
+documentation = "https://docs.rs/crate/parsec-client"
 
 [dependencies]
 parsec-interface = "0.14.0"

--- a/src/core/operation_client.rs
+++ b/src/core/operation_client.rs
@@ -23,12 +23,12 @@ pub struct OperationClient {
     ///
     /// Defaults to a Protobuf converter
     #[derivative(Debug = "ignore")]
-    pub content_converter: Box<dyn Convert>,
+    pub content_converter: Box<dyn Convert + Send + Sync>,
     /// Converter that manages response body conversions
     ///
     /// Defaults to a Protobuf converter
     #[derivative(Debug = "ignore")]
-    pub accept_converter: Box<dyn Convert>,
+    pub accept_converter: Box<dyn Convert + Send + Sync>,
     /// Client for request and response objects
     pub request_client: RequestClient,
 }
@@ -125,14 +125,20 @@ impl crate::BasicClient {
     /// Set the converter used for request bodies handled by this client.
     ///
     /// By default Protobuf will be used for this.
-    pub fn set_request_body_converter(&mut self, content_converter: Box<dyn Convert>) {
+    pub fn set_request_body_converter(
+        &mut self,
+        content_converter: Box<dyn Convert + Send + Sync>,
+    ) {
         self.op_client.content_converter = content_converter;
     }
 
     /// Set the converter used for response bodies handled by this client.
     ///
     /// By default Protobuf will be used for this.
-    pub fn set_response_body_converter(&mut self, accept_converter: Box<dyn Convert>) {
+    pub fn set_response_body_converter(
+        &mut self,
+        accept_converter: Box<dyn Convert + Send + Sync>,
+    ) {
         self.op_client.accept_converter = accept_converter;
     }
 }

--- a/src/core/request_client.rs
+++ b/src/core/request_client.rs
@@ -25,7 +25,7 @@ pub struct RequestClient {
     ///
     /// Defaults to using Unix domain sockets
     #[derivative(Debug = "ignore")]
-    pub ipc_handler: Box<dyn Connect>,
+    pub ipc_handler: Box<dyn Connect + Send + Sync>,
 }
 
 impl RequestClient {
@@ -63,7 +63,7 @@ impl crate::BasicClient {
     /// Set the IPC handler used for communication with the service.
     ///
     /// By default the [Unix domain socket client](../ipc_handler/unix_socket/struct.Client.html) is used.
-    pub fn set_ipc_handler(&mut self, ipc_handler: Box<dyn Connect>) {
+    pub fn set_ipc_handler(&mut self, ipc_handler: Box<dyn Connect + Send + Sync>) {
         self.op_client.request_client.ipc_handler = ipc_handler;
     }
 


### PR DESCRIPTION
This change allows the BasicClient and references to it to be shared
amoung threads.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>