### PR TITLE
Bump version number and fix comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-client"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 description = "Parsec Client library for the Rust ecosystem"

--- a/src/core/basic_client.rs
+++ b/src/core/basic_client.rs
@@ -382,10 +382,6 @@ impl BasicClient {
     /// Several crates (e.g. [`picky-asn1`](https://crates.io/crates/picky-asn1))
     /// can greatly help in dealing with binary encodings.
     ///
-    /// In order to export a public key, the export flag found in the
-    /// [key policy](https://docs.rs/parsec-interface/*/parsec_interface/operations/psa_key_attributes/struct.KeyPolicy.html)
-    /// **must** be `true`.
-    ///
     /// # Errors
     ///
     /// If the implicit client provider is `ProviderID::Core`, a client error


### PR DESCRIPTION
The export_public_key operation is even available if the export flag is
set to false. This flag is only for exporting the full key (private and
public parts).

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>