### PR TITLE
Change socket location and add checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,11 @@ log = "0.4.8"
 derivative = "2.1.1"
 uuid = "0.7.4"
 zeroize = "1.1.0"
+users = "0.10.0"
 
 [dev-dependencies]
 mockstream = "0.0.3"
 
 [features]
-testing = ["parsec-interface/testing"]
+testing = ["parsec-interface/testing", "no-fs-permission-check"]
+no-fs-permission-check = []

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@
 This repository contains a Rust client for consuming the API provided by the [Parsec service](https://github.com/parallaxsecond/parsec).
 The low-level functionality that this library uses for IPC is implemented in the [interface crate](https://github.com/parallaxsecond/parsec-interface-rs).
 
+## Filesystem permission check
+
+To make sure that the client is communicating with a trusted Parsec service, some permission checks
+are done on the socket location. Please see the
+[Recommendations for Secure Deployment](https://parallaxsecond.github.io/parsec-book/threat_model/secure_deployment.html)
+for more information.
+This feature is activated by default but, knowing the risks, you can remove it with:
+```
+cargo build --features no-fs-permission-check
+```
+It is also desactivated for testing.
+
 ## License
 
 The software is provided under Apache-2.0. Contributions to this project are accepted under the same license.
@@ -18,6 +30,7 @@ This project uses the following third party crates:
 * derivative (MIT and Apache-2.0)
 * mockstream (MIT)
 * uuid (MIT and Apache-2.0)
+* users (MIT)
 
 ## Contributing
 


### PR DESCRIPTION
Adds a check for the directory containing the socket. It must be owned
by the parsec user and parsec-clients group and be 750. This check is
disabled for testing.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>