### PR TITLE
Implement provider and auth bootstrapping

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,46 +2,58 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Client app authentication data
 use parsec_interface::requests::{request::RequestAuth, AuthType};
-use parsec_interface::secrecy::{ExposeSecret, Secret};
 
 /// Authentication data used in Parsec requests
 #[derive(Clone, Debug)]
-pub enum AuthenticationData {
+pub enum Authentication {
     /// Used in cases where no authentication is desired or required
     None,
     /// Data used for direct, identity-based authentication
     ///
-    /// The app name is wrapped in a [`Secret`](https://docs.rs/secrecy/*/secrecy/struct.Secret.html).
-    /// The `Secret` struct can be imported from
-    /// `parsec_client::core::secrecy::Secret`.
-    AppIdentity(Secret<String>),
+    /// Warning: Systems using direct authentication require extra measures
+    /// to be as secure as deployments with other authentication mechanisms.
+    /// Please check the
+    /// [Parsec Threat Model](https://parallaxsecond.github.io/parsec-book/parsec_security/parsec_threat_model/threat_model.html)
+    /// for more information.
+    Direct(String),
     /// Used for authentication via Peer Credentials provided by Unix
     /// operating systems for Domain Socket connections.
     UnixPeerCredentials,
 }
 
-impl AuthenticationData {
+impl Authentication {
     /// Get the Parsec authentication type based on the data type
     pub fn auth_type(&self) -> AuthType {
         match self {
-            AuthenticationData::None => AuthType::NoAuth,
-            AuthenticationData::AppIdentity(_) => AuthType::Direct,
-            AuthenticationData::UnixPeerCredentials => AuthType::UnixPeerCredentials,
+            Authentication::None => AuthType::NoAuth,
+            Authentication::Direct(_) => AuthType::Direct,
+            Authentication::UnixPeerCredentials => AuthType::UnixPeerCredentials,
         }
     }
 }
 
-impl From<&AuthenticationData> for RequestAuth {
-    fn from(data: &AuthenticationData) -> Self {
+impl From<&Authentication> for RequestAuth {
+    fn from(data: &Authentication) -> Self {
         match data {
-            AuthenticationData::None => RequestAuth::new(Vec::new()),
-            AuthenticationData::AppIdentity(name) => {
-                RequestAuth::new(name.expose_secret().bytes().collect())
-            }
-            AuthenticationData::UnixPeerCredentials => {
+            Authentication::None => RequestAuth::new(Vec::new()),
+            Authentication::Direct(name) => RequestAuth::new(name.bytes().collect()),
+            Authentication::UnixPeerCredentials => {
                 let current_uid = users::get_current_uid();
                 RequestAuth::new(current_uid.to_le_bytes().to_vec())
             }
+        }
+    }
+}
+
+impl PartialEq for Authentication {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Authentication::None, Authentication::None) => true,
+            (Authentication::UnixPeerCredentials, Authentication::UnixPeerCredentials) => true,
+            (Authentication::Direct(app_name), Authentication::Direct(other_app_name)) => {
+                app_name == other_app_name
+            }
+            _ => false,
         }
     }
 }

--- a/src/core/operation_client.rs
+++ b/src/core/operation_client.rs
@@ -4,7 +4,7 @@
 #![allow(dead_code)]
 
 use super::request_client::RequestClient;
-use crate::auth::AuthenticationData;
+use crate::auth::Authentication;
 use crate::error::{ClientErrorKind, Error, Result};
 use derivative::Derivative;
 use parsec_interface::operations::{Convert, NativeOperation, NativeResult};
@@ -47,7 +47,7 @@ impl OperationClient {
         &self,
         operation: NativeOperation,
         provider: ProviderID,
-        auth: &AuthenticationData,
+        auth: &Authentication,
     ) -> Result<Request> {
         let opcode = operation.opcode();
         let body = self
@@ -100,7 +100,7 @@ impl OperationClient {
         &self,
         operation: NativeOperation,
         provider: ProviderID,
-        auth: &AuthenticationData,
+        auth: &Authentication,
     ) -> Result<NativeResult> {
         let req_opcode = operation.opcode();
         let request = self.operation_to_request(operation, provider, auth)?;

--- a/src/core/testing/mod.rs
+++ b/src/core/testing/mod.rs
@@ -3,11 +3,10 @@
 #![cfg(test)]
 use super::basic_client::BasicClient;
 use super::ipc_handler::{Connect, ReadWrite};
-use crate::auth::AuthenticationData;
+use crate::auth::Authentication;
 use crate::error::Result;
 use mockstream::{FailingMockStream, SyncMockStream};
 use parsec_interface::requests::ProviderID;
-use parsec_interface::secrecy::Secret;
 use std::ops::{Deref, DerefMut};
 use std::time::Duration;
 
@@ -66,14 +65,15 @@ impl DerefMut for TestBasicClient {
 
 impl Default for TestBasicClient {
     fn default() -> Self {
+        let core_client = BasicClient {
+            op_client: Default::default(),
+            auth_data: Authentication::Direct(String::from(DEFAULT_APP_NAME)),
+            implicit_provider: ProviderID::Pkcs11,
+        };
         let mut client = TestBasicClient {
-            core_client: BasicClient::new(AuthenticationData::AppIdentity(Secret::new(
-                String::from(DEFAULT_APP_NAME),
-            ))),
+            core_client,
             mock_stream: SyncMockStream::new(),
         };
-
-        client.core_client.set_implicit_provider(ProviderID::Pkcs11);
 
         client
             .core_client

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,11 @@ pub enum ClientErrorKind {
     InvalidProvider,
     /// Client is missing an implicit provider
     NoProvider,
+    /// Service is missing authenticator or none of the authenticators is supported
+    /// by the client
+    NoAuthenticator,
+    /// Required parameter was not provided
+    MissingParam,
 }
 
 impl From<ClientErrorKind> for Error {
@@ -67,6 +72,8 @@ impl PartialEq for ClientErrorKind {
             }
             ClientErrorKind::InvalidProvider => matches!(other, ClientErrorKind::InvalidProvider),
             ClientErrorKind::NoProvider => matches!(other, ClientErrorKind::NoProvider),
+            ClientErrorKind::NoAuthenticator => matches!(other, ClientErrorKind::NoAuthenticator),
+            ClientErrorKind::MissingParam => matches!(other, ClientErrorKind::MissingParam),
         }
     }
 }
@@ -84,6 +91,8 @@ impl fmt::Display for ClientErrorKind {
                 write!(f, "operation not supported by selected provider")
             }
             ClientErrorKind::NoProvider => write!(f, "client is missing an implicit provider"),
+            ClientErrorKind::NoAuthenticator => write!(f, "service is not reporting any authenticators or none of the reported ones are supported by the client"),
+            ClientErrorKind::MissingParam => write!(f, "one of the `Option` parameters was required but was not provided"),
         }
     }
 }


### PR DESCRIPTION
This commit implements bootstrapping of the `BasicClient`. Previously,
the client would be initialised without any implicit provider and
with a mandatory authentication value. Now the client can be initialised
with default values for both, with a conditional parameter required for
the case when direct authentication is in use.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>