### PR TITLE
Add a JWT-SVID authentication method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # Executing our tests on Arm64 with Travis CI
+dist: focal
 arch: arm64
 language: rust
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4.11"
 derivative = "2.1.1"
 zeroize = "1.1.0"
 users = "0.10.0"
+spiffe = { path = "../../rust-spiffe/spiffe" }
 
 [dev-dependencies]
 mockstream = "0.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,12 @@ log = "0.4.11"
 derivative = "2.1.1"
 zeroize = "1.1.0"
 users = "0.10.0"
-spiffe = { path = "../../rust-spiffe/spiffe" }
+spiffe = { git = "https://github.com/hug-dev/rust-spiffe", branch = "refactor-jwt", optional = true }
 
 [dev-dependencies]
 mockstream = "0.0.3"
 
 [features]
+default = ["spiffe-auth"]
+spiffe-auth = ["spiffe"]
 testing = ["parsec-interface/testing"]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -57,10 +57,10 @@ impl TryFrom<&Authentication> for RequestAuth {
                 let client = JWTClient::new(
                     &env::var("SPIFFE_ENDPOINT_SOCKET").map_err(|e| {
                         error!(
-                            "Can not read the SPIFFE_ENDPOINT_SOCKET environment variable ({}).",
+                            "Cannot read the SPIFFE_ENDPOINT_SOCKET environment variable ({}).",
                             e
                         );
-                        Error::Client(ClientErrorKind::Spiffe)
+                        Error::Client(ClientErrorKind::NoAuthenticator)
                     })?,
                     None,
                 );
@@ -68,7 +68,7 @@ impl TryFrom<&Authentication> for RequestAuth {
 
                 let result = client.fetch(audience, None).map_err(|e| {
                     error!("Error while fetching the JWT-SVID ({}).", e);
-                    Error::Client(ClientErrorKind::Spiffe)
+                    Error::Client(ClientErrorKind::Spiffe(e))
                 })?;
                 Ok(RequestAuth::new(result.svid().as_bytes().into()))
             }
@@ -84,6 +84,7 @@ impl PartialEq for Authentication {
             (Authentication::Direct(app_name), Authentication::Direct(other_app_name)) => {
                 app_name == other_app_name
             }
+            (Authentication::JwtSvid, Authentication::JwtSvid) => true,
             _ => false,
         }
     }

--- a/src/core/basic_client.rs
+++ b/src/core/basic_client.rs
@@ -258,6 +258,7 @@ impl BasicClient {
                 AuthType::UnixPeerCredentials => {
                     self.auth_data = Authentication::UnixPeerCredentials
                 }
+                #[cfg(feature = "spiffe-auth")]
                 AuthType::JwtSvid => self.auth_data = Authentication::JwtSvid,
                 auth => {
                     warn!(

--- a/src/core/basic_client.rs
+++ b/src/core/basic_client.rs
@@ -258,6 +258,7 @@ impl BasicClient {
                 AuthType::UnixPeerCredentials => {
                     self.auth_data = Authentication::UnixPeerCredentials
                 }
+                AuthType::JwtSvid => self.auth_data = Authentication::JwtSvid,
                 auth => {
                     warn!(
                         "Authenticator of type \"{:?}\" not supported by this client library",

--- a/src/core/operation_client.rs
+++ b/src/core/operation_client.rs
@@ -12,6 +12,7 @@ use parsec_interface::operations_protobuf::ProtobufConverter;
 use parsec_interface::requests::{
     request::RequestHeader, Opcode, ProviderID, Request, Response, ResponseStatus,
 };
+use std::convert::TryInto;
 
 /// Low-level client optimised for communicating with the Parsec service at an operation level.
 ///
@@ -66,7 +67,7 @@ impl OperationClient {
         Ok(Request {
             header,
             body,
-            auth: auth.into(),
+            auth: auth.try_into()?,
         })
     }
 

--- a/src/core/testing/core_tests.rs
+++ b/src/core/testing/core_tests.rs
@@ -179,7 +179,10 @@ fn core_provider_for_crypto_test() {
         .psa_destroy_key(String::from("random key"))
         .expect_err("Expected a failure!!");
 
-    assert_eq!(res, Error::Client(ClientErrorKind::InvalidProvider));
+    assert!(matches!(
+        res,
+        Error::Client(ClientErrorKind::InvalidProvider)
+    ));
 }
 
 #[test]
@@ -694,10 +697,10 @@ fn different_response_type_test() {
         .psa_destroy_key(key_name)
         .expect_err("Error was expected");
 
-    assert_eq!(
+    assert!(matches!(
         err,
         Error::Client(ClientErrorKind::InvalidServiceResponseType)
-    );
+    ));
 }
 
 #[test]
@@ -711,7 +714,10 @@ fn response_status_test() {
     client.set_mock_read(&stream.pop_bytes_written());
     let err = client.ping().expect_err("Error was expected");
 
-    assert_eq!(err, Error::Service(status));
+    assert!(matches!(
+        err,
+        Error::Service(ResponseStatus::PsaErrorDataCorrupt)
+    ));
 }
 
 #[test]
@@ -720,10 +726,10 @@ fn malformed_response_test() {
     client.set_mock_read(&[0xcb_u8; 130]);
     let err = client.ping().expect_err("Error was expected");
 
-    assert_eq!(
+    assert!(matches!(
         err,
         Error::Client(ClientErrorKind::Interface(ResponseStatus::InvalidHeader))
-    );
+    ));
 }
 
 #[test]
@@ -788,10 +794,10 @@ fn failing_ipc_test() {
     ))));
 
     let err = client.ping().expect_err("Expected to fail");
-    assert_eq!(
+    assert!(matches!(
         err,
         Error::Client(ClientErrorKind::Interface(ResponseStatus::ConnectionError))
-    );
+    ));
 }
 
 #[test]
@@ -866,10 +872,10 @@ fn set_default_auth_direct() {
         }),
     ));
 
-    assert_eq!(
+    assert!(matches!(
         client.set_default_auth(None).unwrap_err(),
         Error::Client(ClientErrorKind::MissingParam)
-    );
+    ));
 
     client.set_mock_read(&get_response_bytes_from_result(
         NativeResult::ListAuthenticators(operations::list_authenticators::Result {

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,7 @@ pub enum ClientErrorKind {
     /// Required parameter was not provided
     MissingParam,
     /// Error while using the SPIFFE Workload API
+    #[cfg(feature = "spiffe-auth")]
     Spiffe(spiffe::workload::Error),
 }
 
@@ -67,6 +68,7 @@ impl fmt::Display for ClientErrorKind {
             ClientErrorKind::NoProvider => write!(f, "client is missing an implicit provider"),
             ClientErrorKind::NoAuthenticator => write!(f, "service is not reporting any authenticators or none of the reported ones are supported by the client"),
             ClientErrorKind::MissingParam => write!(f, "one of the `Option` parameters was required but was not provided"),
+            #[cfg(feature = "spiffe-auth")]
             ClientErrorKind::Spiffe(error) => error.fmt(f),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,8 @@ pub enum ClientErrorKind {
     NoAuthenticator,
     /// Required parameter was not provided
     MissingParam,
+    /// Error while using the SPIFFE Workload API
+    Spiffe,
 }
 
 impl From<ClientErrorKind> for Error {
@@ -74,6 +76,7 @@ impl PartialEq for ClientErrorKind {
             ClientErrorKind::NoProvider => matches!(other, ClientErrorKind::NoProvider),
             ClientErrorKind::NoAuthenticator => matches!(other, ClientErrorKind::NoAuthenticator),
             ClientErrorKind::MissingParam => matches!(other, ClientErrorKind::MissingParam),
+            ClientErrorKind::Spiffe => matches!(other, ClientErrorKind::Spiffe),
         }
     }
 }
@@ -93,6 +96,7 @@ impl fmt::Display for ClientErrorKind {
             ClientErrorKind::NoProvider => write!(f, "client is missing an implicit provider"),
             ClientErrorKind::NoAuthenticator => write!(f, "service is not reporting any authenticators or none of the reported ones are supported by the client"),
             ClientErrorKind::MissingParam => write!(f, "one of the `Option` parameters was required but was not provided"),
+            ClientErrorKind::Spiffe => write!(f, "error using the SPIFFE Workload API"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use std::error;
 use std::fmt;
 
 /// Enum used to denote errors returned to the library user
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Error {
     /// Errors originating in the service
     Service(ResponseStatus),
@@ -43,41 +43,12 @@ pub enum ClientErrorKind {
     /// Required parameter was not provided
     MissingParam,
     /// Error while using the SPIFFE Workload API
-    Spiffe,
+    Spiffe(spiffe::workload::Error),
 }
 
 impl From<ClientErrorKind> for Error {
     fn from(client_error: ClientErrorKind) -> Self {
         Error::Client(client_error)
-    }
-}
-
-impl PartialEq for ClientErrorKind {
-    fn eq(&self, other: &Self) -> bool {
-        match self {
-            ClientErrorKind::Interface(status) => {
-                if let ClientErrorKind::Interface(other_status) = other {
-                    other_status == status
-                } else {
-                    false
-                }
-            }
-            ClientErrorKind::Ipc(error) => {
-                if let ClientErrorKind::Ipc(other_error) = other {
-                    other_error.kind() == error.kind()
-                } else {
-                    false
-                }
-            }
-            ClientErrorKind::InvalidServiceResponseType => {
-                matches!(other, ClientErrorKind::InvalidServiceResponseType)
-            }
-            ClientErrorKind::InvalidProvider => matches!(other, ClientErrorKind::InvalidProvider),
-            ClientErrorKind::NoProvider => matches!(other, ClientErrorKind::NoProvider),
-            ClientErrorKind::NoAuthenticator => matches!(other, ClientErrorKind::NoAuthenticator),
-            ClientErrorKind::MissingParam => matches!(other, ClientErrorKind::MissingParam),
-            ClientErrorKind::Spiffe => matches!(other, ClientErrorKind::Spiffe),
-        }
     }
 }
 
@@ -96,7 +67,7 @@ impl fmt::Display for ClientErrorKind {
             ClientErrorKind::NoProvider => write!(f, "client is missing an implicit provider"),
             ClientErrorKind::NoAuthenticator => write!(f, "service is not reporting any authenticators or none of the reported ones are supported by the client"),
             ClientErrorKind::MissingParam => write!(f, "one of the `Option` parameters was required but was not provided"),
-            ClientErrorKind::Spiffe => write!(f, "error using the SPIFFE Workload API"),
+            ClientErrorKind::Spiffe(error) => error.fmt(f),
         }
     }
 }

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -13,6 +13,7 @@ set -euf -o pipefail
 ################
 RUST_BACKTRACE=1 cargo build
 RUST_BACKTRACE=1 cargo build --features testing
+RUST_BACKTRACE=1 cargo build --no-default-features
 
 #################
 # Static checks #


### PR DESCRIPTION
Using this method, the client will fetch its JWT-SVID and send it in the
authentication field.
The socket endpoint is found through the SPIFFE_ENDPOINT_SOCKET
environment variable.