### PR TITLE
Consume parsec-interface at 0.22.0 and bump crate to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-client"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 description = "Parsec Client library for the Rust ecosystem"
@@ -13,7 +13,7 @@ edition = "2018"
 documentation = "https://docs.rs/crate/parsec-client"
 
 [dependencies]
-parsec-interface = "0.21.0"
+parsec-interface = "0.22.0"
 num = "0.3.0"
 log = "0.4.11"
 derivative = "2.1.1"


### PR DESCRIPTION
Signed-off-by: Paul Howard <paul.howard@arm.com>