### PR TITLE
Increase the default timeout to 60 seconds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 documentation = "https://docs.rs/crate/parsec-client"
 
 [dependencies]
-parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", rev = "0a20255e5cb73d3c4499a73d147d7c4a2b45ac5f" }
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", rev = "0769c6a88345781cb2a168e2f8c5d5e88561fb88" }
 num = "0.3.0"
 log = "0.4.11"
 derivative = "2.1.1"

--- a/src/core/basic_client.rs
+++ b/src/core/basic_client.rs
@@ -192,7 +192,8 @@ impl BasicClient {
     /// authentication choice
     ///
     /// This client will use the default configuration. That includes using a Protobuf converter
-    /// for message bodies and a Unix Domain Socket IPC handler.
+    /// for message bodies and a Unix Domain Socket IPC handler. The default timeout length is 60
+    /// seconds.
     ///
     /// # Errors
     ///

--- a/src/core/ipc_handler/unix_socket.rs
+++ b/src/core/ipc_handler/unix_socket.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 const DEFAULT_SOCKET_PATH: &str = "/run/parsec/parsec.sock";
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(1);
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// IPC handler for Unix domain sockets
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Gives more time for operations executing on slower machines.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>