### PR TITLE
Bootstrap socket location from env variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4.11"
 derivative = "2.1.1"
 zeroize = "1.1.0"
 users = "0.10.0"
+url = "2.2.0"
 
 [dev-dependencies]
 mockstream = "0.0.3"

--- a/src/core/basic_client.rs
+++ b/src/core/basic_client.rs
@@ -202,7 +202,7 @@ impl BasicClient {
     /// [`set_default_provider`](#method.set_default_provider)
     pub fn new(app_name: Option<String>) -> Result<Self> {
         let mut client = BasicClient {
-            op_client: Default::default(),
+            op_client: OperationClient::new()?,
             auth_data: Authentication::None,
             implicit_provider: ProviderID::Core,
         };

--- a/src/core/operation_client.rs
+++ b/src/core/operation_client.rs
@@ -40,8 +40,11 @@ impl OperationClient {
     /// seconds on reads and writes on the socket. It uses the version 1.0 wire protocol
     /// to form requests, the direct authentication method and protobuf format as
     /// content type.
-    pub fn new() -> OperationClient {
-        Default::default()
+    pub fn new() -> Result<OperationClient> {
+        Ok(OperationClient {
+            request_client: RequestClient::new()?,
+            ..Default::default()
+        })
     }
 
     fn operation_to_request(

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,11 +44,21 @@ pub enum ClientErrorKind {
     MissingParam,
     /// The requested resource was not found.
     NotFound,
+    /// The socket address provided is not valid
+    InvalidSocketAddress,
+    /// The socket URL is invalid
+    InvalidSocketUrl,
 }
 
 impl From<ClientErrorKind> for Error {
     fn from(client_error: ClientErrorKind) -> Self {
         Error::Client(client_error)
+    }
+}
+
+impl From<url::ParseError> for Error {
+    fn from(_: url::ParseError) -> Self {
+        Error::Client(ClientErrorKind::InvalidSocketUrl)
     }
 }
 
@@ -67,7 +77,9 @@ impl fmt::Display for ClientErrorKind {
             ClientErrorKind::NoProvider => write!(f, "client is missing an implicit provider"),
             ClientErrorKind::NoAuthenticator => write!(f, "service is not reporting any authenticators or none of the reported ones are supported by the client"),
             ClientErrorKind::MissingParam => write!(f, "one of the `Option` parameters was required but was not provided"),
-            ClientErrorKind::NotFound => write!(f, "one of the resources required in the operation was not found")
+            ClientErrorKind::NotFound => write!(f, "one of the resources required in the operation was not found"),
+            ClientErrorKind::InvalidSocketAddress => write!(f, "the socket address provided in the URL is not valid"),
+            ClientErrorKind::InvalidSocketUrl => write!(f, "the socket URL is invalid"),
         }
     }
 }


### PR DESCRIPTION
This commit adds functionality to create a IPC connector from a URL and
to bootstrap the IPC handler creation from an environment variable using
this new functionality.
Fixes #37 