### PR TITLE
Add code coverage checking to the nightly run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,8 @@ name: Nightly Checks
 on:
   schedule:
     # Every night at midnight
-    - cron:  '0 0 * * *'
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   dependencies:
@@ -33,3 +34,11 @@ jobs:
         run: cargo install cargo-audit
       - name: Execute cargo audit
         run: cargo audit
+
+  coverage:
+    name: Calculate coverage from tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Execute tarpaulin
+        run: ./tests/coverage.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 *patch
 Cargo.lock
+cobertura.xml

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Contributors to the Parsec project.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euf -o pipefail
+
+cargo install cargo-tarpaulin
+
+cargo tarpaulin --tests --out Xml --exclude-files="src/core/testing/*"
+
+bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This commit adds code coverage checking for the tests in the repo to the
nightly Github Actions run.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>