### PR TITLE
Add dependency on the newest (git only at the moment) parsec-interface.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 documentation = "https://docs.rs/crate/parsec-client"
 
 [dependencies]
-parsec-interface = "0.24.0"
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs.git", rev = "a7f3c7e246a64b9474ca3a0a1365b6deee74e7a4"}
 num = "0.3.0"
 log = "0.4.11"
 derivative = "2.1.1"

--- a/src/core/basic_client.rs
+++ b/src/core/basic_client.rs
@@ -35,7 +35,7 @@ use parsec_interface::operations::psa_sign_hash::Operation as PsaSignHash;
 use parsec_interface::operations::psa_verify_hash::Operation as PsaVerifyHash;
 use parsec_interface::operations::{NativeOperation, NativeResult};
 use parsec_interface::requests::AuthType;
-use parsec_interface::requests::{Opcode, ProviderID};
+use parsec_interface::requests::{Opcode, ProviderId};
 use parsec_interface::secrecy::{ExposeSecret, Secret};
 use std::collections::HashSet;
 use zeroize::Zeroizing;
@@ -69,7 +69,7 @@ use zeroize::Zeroizing;
 ///```no_run
 ///# use parsec_client::auth::Authentication;
 ///# use parsec_client::BasicClient;
-///# use parsec_client::core::interface::requests::ProviderID;
+///# use parsec_client::core::interface::requests::ProviderId;
 ///# let client: BasicClient = BasicClient::new(Some(String::from("app-name"))).unwrap();
 ///let res = client.ping();
 ///
@@ -91,7 +91,7 @@ use zeroize::Zeroizing;
 ///```no_run
 ///# use parsec_client::auth::Authentication;
 ///# use parsec_client::BasicClient;
-///# use parsec_client::core::interface::requests::ProviderID;
+///# use parsec_client::core::interface::requests::ProviderId;
 ///# let client: BasicClient = BasicClient::new(Some(String::from("app-name"))).unwrap();
 ///use parsec_interface::operations::list_providers::Uuid;
 ///
@@ -113,11 +113,11 @@ use zeroize::Zeroizing;
 ///```no_run
 ///# use parsec_client::auth::Authentication;
 ///# use parsec_client::BasicClient;
-///# use parsec_client::core::interface::requests::ProviderID;
+///# use parsec_client::core::interface::requests::ProviderId;
 ///# let mut client: BasicClient = BasicClient::new(Some(String::from("app-name"))).unwrap();
 ///use parsec_client::core::interface::requests::Opcode;
 ///
-///let desired_provider = ProviderID::Pkcs11;
+///let desired_provider = ProviderId::Pkcs11;
 ///let provider_opcodes = client
 ///    .list_opcodes(desired_provider)
 ///    .expect("Failed to list opcodes");
@@ -134,7 +134,7 @@ use zeroize::Zeroizing;
 ///```no_run
 ///# use parsec_client::auth::Authentication;
 ///# use parsec_client::BasicClient;
-///# use parsec_client::core::interface::requests::ProviderID;
+///# use parsec_client::core::interface::requests::ProviderId;
 ///# let client: BasicClient = BasicClient::new(Some(String::from("app-name"))).unwrap();
 ///use parsec_client::core::interface::operations::psa_algorithm::{Algorithm, AsymmetricSignature, Hash};
 ///use parsec_client::core::interface::operations::psa_key_attributes::{Attributes, Lifetime, Policy, Type, UsageFlags};
@@ -178,7 +178,7 @@ use zeroize::Zeroizing;
 pub struct BasicClient {
     pub(crate) op_client: OperationClient,
     pub(crate) auth_data: Authentication,
-    pub(crate) implicit_provider: ProviderID,
+    pub(crate) implicit_provider: ProviderId,
 }
 
 /// Main client functionality.
@@ -204,7 +204,7 @@ impl BasicClient {
         let mut client = BasicClient {
             op_client: OperationClient::new()?,
             auth_data: Authentication::None,
-            implicit_provider: ProviderID::Core,
+            implicit_provider: ProviderId::Core,
         };
         client.set_default_provider()?;
         client.set_default_auth(app_name)?;
@@ -229,7 +229,7 @@ impl BasicClient {
         BasicClient {
             op_client: Default::default(),
             auth_data: Authentication::None,
-            implicit_provider: ProviderID::Core,
+            implicit_provider: ProviderId::Core,
         }
     }
 
@@ -302,22 +302,22 @@ impl BasicClient {
     }
 
     /// Set the provider that the client will be implicitly working with.
-    pub fn set_implicit_provider(&mut self, provider: ProviderID) {
+    pub fn set_implicit_provider(&mut self, provider: ProviderId) {
         self.implicit_provider = provider;
     }
 
     /// Retrieve client's implicit provider.
-    pub fn implicit_provider(&self) -> ProviderID {
+    pub fn implicit_provider(&self) -> ProviderId {
         self.implicit_provider
     }
 
     /// **[Core Operation]** List the opcodes supported by the specified provider.
-    pub fn list_opcodes(&self, provider: ProviderID) -> Result<HashSet<Opcode>> {
+    pub fn list_opcodes(&self, provider: ProviderId) -> Result<HashSet<Opcode>> {
         let res = self.op_client.process_operation(
             NativeOperation::ListOpcodes(ListOpcodes {
                 provider_id: provider,
             }),
-            ProviderID::Core,
+            ProviderId::Core,
             &self.auth_data,
         )?;
 
@@ -334,7 +334,7 @@ impl BasicClient {
     pub fn list_providers(&self) -> Result<Vec<ProviderInfo>> {
         let res = self.op_client.process_operation(
             NativeOperation::ListProviders(ListProviders {}),
-            ProviderID::Core,
+            ProviderId::Core,
             &self.auth_data,
         )?;
         if let NativeResult::ListProviders(res) = res {
@@ -350,7 +350,7 @@ impl BasicClient {
     pub fn list_authenticators(&self) -> Result<Vec<AuthenticatorInfo>> {
         let res = self.op_client.process_operation(
             NativeOperation::ListAuthenticators(ListAuthenticators {}),
-            ProviderID::Core,
+            ProviderId::Core,
             &self.auth_data,
         )?;
         if let NativeResult::ListAuthenticators(res) = res {
@@ -366,7 +366,7 @@ impl BasicClient {
     pub fn list_keys(&self) -> Result<Vec<KeyInfo>> {
         let res = self.op_client.process_operation(
             NativeOperation::ListKeys(ListKeys {}),
-            ProviderID::Core,
+            ProviderId::Core,
             &self.auth_data,
         )?;
         if let NativeResult::ListKeys(res) = res {
@@ -395,7 +395,7 @@ impl BasicClient {
     pub fn list_clients(&self) -> Result<Vec<String>> {
         let res = self.op_client.process_operation(
             NativeOperation::ListClients(ListClients {}),
-            ProviderID::Core,
+            ProviderId::Core,
             &self.auth_data,
         )?;
         if let NativeResult::ListClients(res) = res {
@@ -411,7 +411,7 @@ impl BasicClient {
     pub fn delete_client(&self, client: String) -> Result<()> {
         let res = self.op_client.process_operation(
             NativeOperation::DeleteClient(DeleteClient { client }),
-            ProviderID::Core,
+            ProviderId::Core,
             &self.auth_data,
         )?;
         if let NativeResult::DeleteClient(_) = res {
@@ -431,7 +431,7 @@ impl BasicClient {
     pub fn ping(&self) -> Result<(u8, u8)> {
         let res = self.op_client.process_operation(
             NativeOperation::Ping(Ping {}),
-            ProviderID::Core,
+            ProviderId::Core,
             &Authentication::None,
         )?;
 
@@ -460,7 +460,7 @@ impl BasicClient {
     /// If this method returns an error, no key will have been generated and
     /// the name used will still be available for another key.
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -490,7 +490,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -530,7 +530,7 @@ impl BasicClient {
     /// If this method returns an error, no key will have been imported and the
     /// name used will still be available for another key.
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -568,7 +568,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -602,7 +602,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -641,7 +641,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -690,7 +690,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -736,7 +736,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -788,7 +788,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -833,7 +833,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -866,7 +866,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -901,7 +901,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -954,7 +954,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -1005,7 +1005,7 @@ impl BasicClient {
     ///
     /// # Errors
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -1044,7 +1044,7 @@ impl BasicClient {
     ///
     /// If this method returns an error, no bytes will have been generated.
     ///
-    /// If the implicit client provider is `ProviderID::Core`, a client error
+    /// If the implicit client provider is `ProviderId::Core`, a client error
     /// of `InvalidProvider` type is returned.
     ///
     /// See the operation-specific response codes returned by the service
@@ -1069,9 +1069,9 @@ impl BasicClient {
         }
     }
 
-    fn can_provide_crypto(&self) -> Result<ProviderID> {
+    fn can_provide_crypto(&self) -> Result<ProviderId> {
         match self.implicit_provider {
-            ProviderID::Core => Err(Error::Client(ClientErrorKind::InvalidProvider)),
+            ProviderId::Core => Err(Error::Client(ClientErrorKind::InvalidProvider)),
             crypto_provider => Ok(crypto_provider),
         }
     }

--- a/src/core/basic_client.rs
+++ b/src/core/basic_client.rs
@@ -800,10 +800,7 @@ impl BasicClient {
         ciphertext: &[u8],
         salt: Option<&[u8]>,
     ) -> Result<Vec<u8>> {
-        let salt = match salt {
-            Some(salt) => Some(Zeroizing::new(salt.to_vec())),
-            None => None,
-        };
+        let salt = salt.map(|salt| Zeroizing::new(salt.to_vec()));
         let crypto_provider = self.can_provide_crypto()?;
 
         let op = PsaAsymDecrypt {

--- a/src/core/operation_client.rs
+++ b/src/core/operation_client.rs
@@ -10,7 +10,7 @@ use derivative::Derivative;
 use parsec_interface::operations::{Convert, NativeOperation, NativeResult};
 use parsec_interface::operations_protobuf::ProtobufConverter;
 use parsec_interface::requests::{
-    request::RequestHeader, Opcode, ProviderID, Request, Response, ResponseStatus,
+    request::RequestHeader, Opcode, ProviderId, Request, Response, ResponseStatus,
 };
 use std::convert::TryInto;
 
@@ -50,7 +50,7 @@ impl OperationClient {
     fn operation_to_request(
         &self,
         operation: NativeOperation,
-        provider: ProviderID,
+        provider: ProviderId,
         auth: &Authentication,
     ) -> Result<Request> {
         let opcode = operation.opcode();
@@ -103,7 +103,7 @@ impl OperationClient {
     pub fn process_operation(
         &self,
         operation: NativeOperation,
-        provider: ProviderID,
+        provider: ProviderId,
         auth: &Authentication,
     ) -> Result<NativeResult> {
         let req_opcode = operation.opcode();

--- a/src/core/testing/core_tests.rs
+++ b/src/core/testing/core_tests.rs
@@ -13,7 +13,7 @@ use parsec_interface::operations::psa_key_attributes::*;
 use parsec_interface::operations::Convert;
 use parsec_interface::operations::{NativeOperation, NativeResult};
 use parsec_interface::operations_protobuf::ProtobufConverter;
-use parsec_interface::requests::ProviderID;
+use parsec_interface::requests::ProviderId;
 use parsec_interface::requests::Response;
 use parsec_interface::requests::ResponseStatus;
 use parsec_interface::requests::{request::RequestHeader, Request};
@@ -25,7 +25,7 @@ use zeroize::Zeroizing;
 
 const PROTOBUF_CONVERTER: ProtobufConverter = ProtobufConverter {};
 const REQ_HEADER: RequestHeader = RequestHeader {
-    provider: ProviderID::Core,
+    provider: ProviderId::Core,
     session: 0,
     content_type: BodyType::Protobuf,
     accept_type: BodyType::Protobuf,
@@ -75,16 +75,15 @@ fn ping_test() {
 #[test]
 fn list_provider_test() {
     let mut client: TestBasicClient = Default::default();
-    let mut provider_info = Vec::new();
-    provider_info.push(ProviderInfo {
+    let provider_info = vec![ProviderInfo {
         uuid: Uuid::nil(),
         description: String::from("Some empty provider"),
         vendor: String::from("Arm Ltd."),
         version_maj: 1,
         version_min: 0,
         version_rev: 0,
-        id: ProviderID::Core,
-    });
+        id: ProviderId::Core,
+    }];
     client.set_mock_read(&get_response_bytes_from_result(
         NativeResult::ListProviders(operations::list_providers::Result {
             providers: provider_info,
@@ -109,7 +108,7 @@ fn list_opcodes_test() {
         operations::list_opcodes::Result { opcodes },
     )));
     let opcodes = client
-        .list_opcodes(ProviderID::MbedCrypto)
+        .list_opcodes(ProviderId::MbedCrypto)
         .expect("Failed to retrieve opcodes");
     // Check request:
     // ListOpcodes request is empty so no checking to be done
@@ -122,9 +121,7 @@ fn list_opcodes_test() {
 #[test]
 fn list_clients_test() {
     let mut client: TestBasicClient = Default::default();
-    let mut clients = Vec::new();
-    clients.push("toto".to_string());
-    clients.push("tata".to_string());
+    let clients = vec!["toto".to_string(), "tata".to_string()];
     client.set_mock_read(&get_response_bytes_from_result(NativeResult::ListClients(
         operations::list_clients::Result { clients },
     )));
@@ -162,9 +159,8 @@ fn list_keys_test() {
     };
 
     let mut client: TestBasicClient = Default::default();
-    let mut key_info = Vec::new();
-    key_info.push(KeyInfo {
-        provider_id: ProviderID::MbedCrypto,
+    let key_info = vec![KeyInfo {
+        provider_id: ProviderId::MbedCrypto,
         name: String::from("Foo"),
         attributes: Attributes {
             lifetime: Lifetime::Persistent,
@@ -190,7 +186,7 @@ fn list_keys_test() {
                 ),
             },
         },
-    });
+    }];
 
     client.set_mock_read(&get_response_bytes_from_result(NativeResult::ListKeys(
         operations::list_keys::Result { keys: key_info },
@@ -203,14 +199,14 @@ fn list_keys_test() {
     // Check response:
     assert_eq!(keys.len(), 1);
     assert_eq!(keys[0].name, "Foo");
-    assert_eq!(keys[0].provider_id, ProviderID::MbedCrypto);
+    assert_eq!(keys[0].provider_id, ProviderId::MbedCrypto);
 }
 
 #[test]
 fn core_provider_for_crypto_test() {
     let mut client: TestBasicClient = Default::default();
 
-    client.set_implicit_provider(ProviderID::Core);
+    client.set_implicit_provider(ProviderId::Core);
     let res = client
         .psa_destroy_key(String::from("random key"))
         .expect_err("Expected a failure!!");

--- a/src/core/testing/mod.rs
+++ b/src/core/testing/mod.rs
@@ -6,7 +6,7 @@ use super::ipc_handler::{Connect, ReadWrite};
 use crate::auth::Authentication;
 use crate::error::Result;
 use mockstream::{FailingMockStream, SyncMockStream};
-use parsec_interface::requests::ProviderID;
+use parsec_interface::requests::ProviderId;
 use std::ops::{Deref, DerefMut};
 use std::time::Duration;
 
@@ -68,7 +68,7 @@ impl Default for TestBasicClient {
         let core_client = BasicClient {
             op_client: Default::default(),
             auth_data: Authentication::Direct(String::from(DEFAULT_APP_NAME)),
-            implicit_provider: ProviderID::Pkcs11,
+            implicit_provider: ProviderId::Pkcs11,
         };
         let mut client = TestBasicClient {
             core_client,


### PR DESCRIPTION
Add dependency on the newest (git only at the moment) parsec-interface with support for sign/verify message.
Plenty of transitions from 'ProviderID' to 'ProviderId'.
Few linter corrections in tests.

Signed-off-by: Robert Drazkowski <Robert.Drazkowski@globallogic.com>