### PR TITLE
Add SPIFFE authentication via the new crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,12 @@ derivative = "2.1.1"
 zeroize = "1.1.0"
 users = "0.10.0"
 url = "2.2.0"
+spiffe = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 mockstream = "0.0.3"
 
 [features]
 default = []
+spiffe-auth = ["spiffe"]
 testing = ["parsec-interface/testing"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 This repository contains a Rust client for consuming the API provided by the [Parsec service](https://github.com/parallaxsecond/parsec).
 The low-level functionality that this library uses for IPC is implemented in the [interface crate](https://github.com/parallaxsecond/parsec-interface-rs).
 
-Check out the `spiffe` branch for JWT SVID authentication feature.
+When using the JWT-SVID authentication method, the client will expect the `SPIFFE_ENDPOINT_SOCKET` environment variable to contain the path of the Workload API endpoint.
+See the [SPIFFE Workload Endpoint](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Workload_Endpoint.md#4-locating-the-endpoint) for more information.
 
 ## Locating the Parsec endpoint
 

--- a/src/core/basic_client.rs
+++ b/src/core/basic_client.rs
@@ -263,6 +263,8 @@ impl BasicClient {
                 AuthType::UnixPeerCredentials => {
                     self.auth_data = Authentication::UnixPeerCredentials
                 }
+                #[cfg(feature = "spiffe-auth")]
+                AuthType::JwtSvid => self.auth_data = Authentication::JwtSvid,
                 auth => {
                     warn!(
                         "Authenticator of type \"{:?}\" not supported by this client library",

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,9 @@ pub enum ClientErrorKind {
     InvalidSocketAddress,
     /// The socket URL is invalid
     InvalidSocketUrl,
+    /// Error while using the SPIFFE Workload API
+    #[cfg(feature = "spiffe-auth")]
+    Spiffe(spiffe::workload_api::client::ClientError),
 }
 
 impl From<ClientErrorKind> for Error {
@@ -80,6 +83,8 @@ impl fmt::Display for ClientErrorKind {
             ClientErrorKind::NotFound => write!(f, "one of the resources required in the operation was not found"),
             ClientErrorKind::InvalidSocketAddress => write!(f, "the socket address provided in the URL is not valid"),
             ClientErrorKind::InvalidSocketUrl => write!(f, "the socket URL is invalid"),
+            #[cfg(feature = "spiffe-auth")]
+            ClientErrorKind::Spiffe(error) => error.fmt(f),
         }
     }
 }

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -13,6 +13,7 @@ set -euf -o pipefail
 ################
 RUST_BACKTRACE=1 cargo build
 RUST_BACKTRACE=1 cargo build --features testing
+RUST_BACKTRACE=1 cargo build --features spiffe-auth
 RUST_BACKTRACE=1 cargo build --no-default-features
 
 #################


### PR DESCRIPTION
As the number of dependencies introduced by the new crate is high, add
it as a separate feature.
The functionality is the same as the `spiffe` branch but with a released
crate named "spiffe".

**Note:**  the `spiffe` branch will be deleted when this PR is merged.