### PR TITLE
Changed to use &str for key_name parameters.

### DIFF
--- a/src/core/basic_client.rs
+++ b/src/core/basic_client.rs
@@ -173,7 +173,7 @@ use zeroize::Zeroizing;
 ///};
 ///
 ///client
-///    .psa_generate_key(key_name.clone(), key_attrs)
+///    .psa_generate_key(&key_name, key_attrs)
 ///    .expect("Failed to create key!");
 ///```
 #[derive(Debug)]
@@ -469,11 +469,11 @@ impl BasicClient {
     ///
     /// See the operation-specific response codes returned by the service
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_generate_key.html#specific-response-status-codes).
-    pub fn psa_generate_key(&self, key_name: String, key_attributes: Attributes) -> Result<()> {
+    pub fn psa_generate_key(&self, key_name: &str, key_attributes: Attributes) -> Result<()> {
         let crypto_provider = self.can_provide_crypto()?;
 
         let op = PsaGenerateKey {
-            key_name,
+            key_name: String::from(key_name),
             attributes: key_attributes,
         };
 
@@ -499,10 +499,12 @@ impl BasicClient {
     ///
     /// See the operation-specific response codes returned by the service
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_destroy_key.html#specific-response-status-codes).
-    pub fn psa_destroy_key(&self, key_name: String) -> Result<()> {
+    pub fn psa_destroy_key(&self, key_name: &str) -> Result<()> {
         let crypto_provider = self.can_provide_crypto()?;
 
-        let op = PsaDestroyKey { key_name };
+        let op = PsaDestroyKey {
+            key_name: String::from(key_name),
+        };
 
         let _ = self.op_client.process_operation(
             NativeOperation::PsaDestroyKey(op),
@@ -541,7 +543,7 @@ impl BasicClient {
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_import_key.html#specific-response-status-codes).
     pub fn psa_import_key(
         &self,
-        key_name: String,
+        key_name: &str,
         key_material: &[u8],
         key_attributes: Attributes,
     ) -> Result<()> {
@@ -549,7 +551,7 @@ impl BasicClient {
         let crypto_provider = self.can_provide_crypto()?;
 
         let op = PsaImportKey {
-            key_name,
+            key_name: String::from(key_name),
             attributes: key_attributes,
             data: key_material,
         };
@@ -577,10 +579,12 @@ impl BasicClient {
     ///
     /// See the operation-specific response codes returned by the service
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_export_public_key.html#specific-response-status-codes).
-    pub fn psa_export_public_key(&self, key_name: String) -> Result<Vec<u8>> {
+    pub fn psa_export_public_key(&self, key_name: &str) -> Result<Vec<u8>> {
         let crypto_provider = self.can_provide_crypto()?;
 
-        let op = PsaExportPublicKey { key_name };
+        let op = PsaExportPublicKey {
+            key_name: String::from(key_name),
+        };
 
         let res = self.op_client.process_operation(
             NativeOperation::PsaExportPublicKey(op),
@@ -611,10 +615,12 @@ impl BasicClient {
     ///
     /// See the operation-specific response codes returned by the service
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_export_key.html#specific-response-status-codes).
-    pub fn psa_export_key(&self, key_name: String) -> Result<Vec<u8>> {
+    pub fn psa_export_key(&self, key_name: &str) -> Result<Vec<u8>> {
         let crypto_provider = self.can_provide_crypto()?;
 
-        let op = PsaExportKey { key_name };
+        let op = PsaExportKey {
+            key_name: String::from(key_name),
+        };
 
         let res = self.op_client.process_operation(
             NativeOperation::PsaExportKey(op),
@@ -652,7 +658,7 @@ impl BasicClient {
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_sign_hash.html#specific-response-status-codes).
     pub fn psa_sign_hash(
         &self,
-        key_name: String,
+        key_name: &str,
         hash: &[u8],
         sign_algorithm: AsymmetricSignature,
     ) -> Result<Vec<u8>> {
@@ -660,7 +666,7 @@ impl BasicClient {
         let crypto_provider = self.can_provide_crypto()?;
 
         let op = PsaSignHash {
-            key_name,
+            key_name: String::from(key_name),
             alg: sign_algorithm,
             hash,
         };
@@ -701,7 +707,7 @@ impl BasicClient {
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_verify_hash.html#specific-response-status-codes).
     pub fn psa_verify_hash(
         &self,
-        key_name: String,
+        key_name: &str,
         hash: &[u8],
         sign_algorithm: AsymmetricSignature,
         signature: &[u8],
@@ -711,7 +717,7 @@ impl BasicClient {
         let crypto_provider = self.can_provide_crypto()?;
 
         let op = PsaVerifyHash {
-            key_name,
+            key_name: String::from(key_name),
             alg: sign_algorithm,
             hash,
             signature,
@@ -744,7 +750,7 @@ impl BasicClient {
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_sign_message.html#specific-response-status-codes).
     pub fn psa_sign_message(
         &self,
-        key_name: String,
+        key_name: &str,
         msg: &[u8],
         sign_algorithm: AsymmetricSignature,
     ) -> Result<Vec<u8>> {
@@ -752,7 +758,7 @@ impl BasicClient {
         let crypto_provider = self.can_provide_crypto()?;
 
         let op = PsaSignMessage {
-            key_name,
+            key_name: String::from(key_name),
             alg: sign_algorithm,
             message,
         };
@@ -790,7 +796,7 @@ impl BasicClient {
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_verify_message.html#specific-response-status-codes).
     pub fn psa_verify_message(
         &self,
-        key_name: String,
+        key_name: &str,
         msg: &[u8],
         sign_algorithm: AsymmetricSignature,
         signature: &[u8],
@@ -800,7 +806,7 @@ impl BasicClient {
         let crypto_provider = self.can_provide_crypto()?;
 
         let op = PsaVerifyMessage {
-            key_name,
+            key_name: String::from(key_name),
             alg: sign_algorithm,
             message,
             signature,
@@ -836,7 +842,7 @@ impl BasicClient {
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_asymmetric_encrypt.html#specific-response-status-codes).
     pub fn psa_asymmetric_encrypt(
         &self,
-        key_name: String,
+        key_name: &str,
         encrypt_alg: AsymmetricEncryption,
         plaintext: &[u8],
         salt: Option<&[u8]>,
@@ -845,7 +851,7 @@ impl BasicClient {
         let crypto_provider = self.can_provide_crypto()?;
 
         let op = PsaAsymEncrypt {
-            key_name,
+            key_name: String::from(key_name),
             alg: encrypt_alg,
             plaintext: plaintext.to_vec().into(),
             salt,
@@ -888,7 +894,7 @@ impl BasicClient {
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_asymmetric_decrypt.html#specific-response-status-codes).
     pub fn psa_asymmetric_decrypt(
         &self,
-        key_name: String,
+        key_name: &str,
         encrypt_alg: AsymmetricEncryption,
         ciphertext: &[u8],
         salt: Option<&[u8]>,
@@ -897,7 +903,7 @@ impl BasicClient {
         let crypto_provider = self.can_provide_crypto()?;
 
         let op = PsaAsymDecrypt {
-            key_name,
+            key_name: String::from(key_name),
             alg: encrypt_alg,
             ciphertext: Zeroizing::new(ciphertext.to_vec()),
             salt,
@@ -998,7 +1004,7 @@ impl BasicClient {
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_aead_encrypt.html#specific-response-status-codes).
     pub fn psa_aead_encrypt(
         &self,
-        key_name: String,
+        key_name: &str,
         encrypt_alg: Aead,
         nonce: &[u8],
         additional_data: &[u8],
@@ -1007,7 +1013,7 @@ impl BasicClient {
         let crypto_provider = self.can_provide_crypto()?;
 
         let op = PsaAeadEncrypt {
-            key_name,
+            key_name: String::from(key_name),
             alg: encrypt_alg,
             nonce: nonce.to_vec().into(),
             additional_data: additional_data.to_vec().into(),
@@ -1051,7 +1057,7 @@ impl BasicClient {
     /// [here](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/psa_aead_decrypt.html#specific-response-status-codes).
     pub fn psa_aead_decrypt(
         &self,
-        key_name: String,
+        key_name: &str,
         encrypt_alg: Aead,
         nonce: &[u8],
         additional_data: &[u8],
@@ -1060,7 +1066,7 @@ impl BasicClient {
         let crypto_provider = self.can_provide_crypto()?;
 
         let op = PsaAeadDecrypt {
-            key_name,
+            key_name: String::from(key_name),
             alg: encrypt_alg,
             nonce: nonce.to_vec().into(),
             additional_data: additional_data.to_vec().into(),
@@ -1103,12 +1109,12 @@ impl BasicClient {
     pub fn psa_raw_key_agreement(
         &self,
         alg: RawKeyAgreement,
-        private_key_name: String,
+        private_key_name: &str,
         peer_key: &[u8],
     ) -> Result<Vec<u8>> {
         let op = PsaRawKeyAgreement {
             alg,
-            private_key_name,
+            private_key_name: String::from(private_key_name),
             peer_key: Zeroizing::new(peer_key.to_vec()),
         };
         let crypto_provider = self.can_provide_crypto()?;

--- a/src/core/testing/core_tests.rs
+++ b/src/core/testing/core_tests.rs
@@ -208,7 +208,7 @@ fn core_provider_for_crypto_test() {
 
     client.set_implicit_provider(ProviderId::Core);
     let res = client
-        .psa_destroy_key(String::from("random key"))
+        .psa_destroy_key("random key")
         .expect_err("Expected a failure!!");
 
     assert!(matches!(
@@ -246,7 +246,7 @@ fn psa_generate_key_test() {
     };
 
     client
-        .psa_generate_key(key_name.clone(), key_attrs)
+        .psa_generate_key(&key_name, key_attrs)
         .expect("failed to generate key");
 
     // Check request:
@@ -270,7 +270,7 @@ fn psa_destroy_key_test() {
     ));
     let key_name = String::from("key-name");
     client
-        .psa_destroy_key(key_name.clone())
+        .psa_destroy_key(&key_name)
         .expect("Failed to call destroy key");
 
     // Check request:
@@ -314,7 +314,7 @@ fn psa_import_key_test() {
     };
     let key_data = vec![0xff_u8; 128];
     client
-        .psa_import_key(key_name.clone(), &key_data, key_attrs)
+        .psa_import_key(&key_name, &key_data, key_attrs)
         .unwrap();
 
     // Check request:
@@ -345,7 +345,7 @@ fn psa_export_public_key_test() {
     // Check response:
     assert_eq!(
         client
-            .psa_export_public_key(key_name.clone())
+            .psa_export_public_key(&key_name)
             .expect("Failed to export public key"),
         key_data
     );
@@ -373,7 +373,7 @@ fn psa_export_key_test() {
     // Check response:
     assert_eq!(
         client
-            .psa_export_key(key_name.clone())
+            .psa_export_key(&key_name)
             .expect("Failed to export key"),
         key_data
     );
@@ -405,7 +405,7 @@ fn psa_sign_hash_test() {
     // Check response:
     assert_eq!(
         client
-            .psa_sign_hash(key_name.clone(), &hash, sign_algorithm)
+            .psa_sign_hash(&key_name, &hash, sign_algorithm)
             .expect("Failed to sign hash"),
         signature
     );
@@ -462,7 +462,7 @@ fn verify_hash_test() {
     ));
 
     client
-        .psa_verify_hash(key_name.clone(), &hash, sign_algorithm, &signature)
+        .psa_verify_hash(&key_name, &hash, sign_algorithm, &signature)
         .expect("Failed to sign hash");
 
     // Check request:
@@ -498,7 +498,7 @@ fn psa_sign_message_test() {
     // Check response:
     assert_eq!(
         client
-            .psa_sign_message(key_name.clone(), &msg, sign_algorithm)
+            .psa_sign_message(&key_name, &msg, sign_algorithm)
             .expect("Failed to sign message"),
         signature
     );
@@ -528,7 +528,7 @@ fn verify_message_test() {
     ));
 
     client
-        .psa_verify_message(key_name.clone(), &msg, sign_algorithm, &signature)
+        .psa_verify_message(&key_name, &msg, sign_algorithm, &signature)
         .expect("Failed to sign hash");
 
     // Check request:
@@ -562,7 +562,7 @@ fn asymmetric_encrypt_test() {
     // Check response:
     assert_eq!(
         client
-            .psa_asymmetric_encrypt(key_name.clone(), encrypt_algorithm, &plaintext, None)
+            .psa_asymmetric_encrypt(&key_name, encrypt_algorithm, &plaintext, None)
             .expect("Failed to encrypt message"),
         ciphertext
     );
@@ -595,7 +595,7 @@ fn asymmetric_decrypt_test() {
     // Check response
     assert_eq!(
         client
-            .psa_asymmetric_decrypt(key_name.clone(), encrypt_algorithm, &ciphertext, None)
+            .psa_asymmetric_decrypt(&key_name, encrypt_algorithm, &ciphertext, None)
             .expect("Failed to decrypt message"),
         plaintext
     );
@@ -631,7 +631,7 @@ fn aead_encrypt_test() {
     assert_eq!(
         client
             .psa_aead_encrypt(
-                key_name.clone(),
+                &key_name,
                 encrypt_algorithm,
                 &nonce,
                 &additional_data,
@@ -673,7 +673,7 @@ fn aead_decrypt_test() {
     assert_eq!(
         client
             .psa_aead_decrypt(
-                key_name.clone(),
+                &key_name,
                 encrypt_algorithm,
                 &nonce,
                 &additional_data,
@@ -768,7 +768,7 @@ fn raw_key_agreement_test() {
     // Check response
     assert_eq!(
         client
-            .psa_raw_key_agreement(agreement_alg, key_name.clone(), &peer_key)
+            .psa_raw_key_agreement(agreement_alg, &key_name, &peer_key)
             .expect("Failed key agreement"),
         shared_secret
     );
@@ -792,7 +792,7 @@ fn different_response_type_test() {
     ));
     let key_name = String::from("key-name");
     let err = client
-        .psa_destroy_key(key_name)
+        .psa_destroy_key(&key_name)
         .expect_err("Error was expected");
 
     assert!(matches!(
@@ -853,7 +853,7 @@ fn auth_value_test() {
     ));
     let key_name = String::from("key-name");
     client
-        .psa_destroy_key(key_name)
+        .psa_destroy_key(&key_name)
         .expect("Failed to call destroy key");
 
     let req = get_req_from_bytes(client.get_mock_write());
@@ -872,7 +872,7 @@ fn peer_credential_auth_test() {
     ));
     let key_name = String::from("key-name");
     client
-        .psa_destroy_key(key_name)
+        .psa_destroy_key(&key_name)
         .expect("Failed to call destroy key");
 
     let req = get_req_from_bytes(client.get_mock_write());


### PR DESCRIPTION
Used to have to call key_name.clone() when passing it as an argument.
Now it follows the pattern of psa_generate_key(&key_name, key_attrs)

Issue #81

Signed-off-by: Matt Davis <matt.davis@arm.com>