### PR TITLE
Added CanDoCrypto to basic client.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 documentation = "https://docs.rs/crate/parsec-client"
 
 [dependencies]
-parsec-interface = "0.25.0"
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", branch = "can-do-crypto" }
 num = "0.3.0"
 log = "0.4.11"
 derivative = "2.1.1"


### PR DESCRIPTION
Added the CanDoCrypto operation to the basic client by adding the can_do_crypto function to the implementation of BasicClient

Signed-off-by: Sam Davis <sam.davis@arm.com>