### PR TITLE
Build parse-interface with deprecated primitive feature changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 documentation = "https://docs.rs/crate/parsec-client"
 
 [dependencies]
-parsec-interface = "0.26.0"
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs.git", rev = "b2a4b6656f693b61f7fdac593de5fbbb1853d58e" }
 num = "0.3.0"
 log = "0.4.11"
 derivative = "2.1.1"


### PR DESCRIPTION
This change points to the `parsec-interface` revision, which includes the deprecated primitives' checks.
Relates to: https://github.com/parallaxsecond/parsec/issues/119 

Signed-off-by: Mohamed Omar Asaker <mohamed.omarasaker@arm.com>