### PR TITLE
Remove unmaintained 'users' crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ num = "0.4.0"
 log = "0.4.17"
 derivative = "2.1.1"
 zeroize = "1.1.0"
-users = "0.11.0"
 url = "2.2.0"
 spiffe = { version = "0.2.0", optional = true }
+libc = "0.2.147"
 
 [dev-dependencies]
 mockstream = "0.0.3"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -49,7 +49,7 @@ impl TryFrom<&Authentication> for RequestAuth {
             Authentication::None => Ok(RequestAuth::new(Vec::new())),
             Authentication::Direct(name) => Ok(RequestAuth::new(name.bytes().collect())),
             Authentication::UnixPeerCredentials => {
-                let current_uid = users::get_current_uid();
+                let current_uid: libc::uid_t = unsafe { libc::getuid() };
                 Ok(RequestAuth::new(current_uid.to_le_bytes().to_vec()))
             }
             #[cfg(feature = "spiffe-auth")]

--- a/src/core/testing/core_tests.rs
+++ b/src/core/testing/core_tests.rs
@@ -854,8 +854,9 @@ fn peer_credential_auth_test() {
         .expect("Failed to call destroy key");
 
     let req = get_req_from_bytes(client.get_mock_write());
+    let current_uid: libc::uid_t = unsafe { libc::getuid() };
     assert_eq!(
-        &users::get_current_uid().to_le_bytes().to_vec(),
+        &current_uid.to_le_bytes().to_vec(),
         req.auth.buffer.expose_secret()
     );
 }


### PR DESCRIPTION
The 'users' crate is currently being flagged as unmaintained in https://rustsec.org/advisories/RUSTSEC-2023-0040.html .
It is currently only being used to get the uid of the user of a running process.

 * Replace all users::get_current_uid() calls with libc::getuid() calls.
 * Remove the users crate from Cargo.toml.
 * Add libc to the Cargo.toml to call libc::getuid() instead.

Please refer to https://github.com/parallaxsecond/parsec/pull/684 for more information on this PR.