### PR TITLE
.cargo/audit: Ignore unmaintained ansi_term util spiffe is upgraded

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,5 @@
 [advisories]
-ignore = []
+ignore = ["RUSTSEC-2021-0139"] # Remove when spiffe is upgraded
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,11 @@ on:
     # Every night at midnight
     - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      rev:
+        description: "Revision hash to run against"
+        required: false
+        default: ""
 
 jobs:
   dependencies:
@@ -12,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: "${{ github.event.inputs.rev }}"
       - name: Install latest Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -26,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: "${{ github.event.inputs.rev }}"
       - name: Install latest Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -40,5 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          ref: "${{ github.event.inputs.rev }}"
       - name: Execute tarpaulin
         run: ./tests/coverage.sh


### PR DESCRIPTION
https://github.com/parallaxsecond/parsec-client-rust/actions/runs/6419270620/job/17428760394
Issue is generated from spiffe, which will be upgraded post-release