### PR TITLE
ci/nightly: Run parsec-mock for coverage tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,4 +52,10 @@ jobs:
         with:
           ref: "${{ github.event.inputs.rev }}"
       - name: Execute tarpaulin
-        run: ./tests/coverage.sh
+        run: |
+          curl -s -N -L https://github.com/parallaxsecond/parsec-mock/archive/refs/tags/0.1.1.tar.gz | tar xz
+          cd parsec-mock-0.1.1/
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          cd ..
+          ./tests/coverage.sh

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -7,6 +7,21 @@ set -euf -o pipefail
 
 cargo install cargo-tarpaulin
 
+######################
+# Start Mock Service #
+######################
+CURRENT_PATH=$(pwd)
+cd parsec-mock-0.1.1
+python parsec_mock/parsec_mock.py --parsec-socket $CURRENT_PATH/parsec_mock.sock &
+while [[ ! -S $CURRENT_PATH/parsec_mock.sock ]]; do
+	sleep 5
+done
+cd ..
+export PARSEC_SERVICE_ENDPOINT="unix://$CURRENT_PATH/parsec_mock.sock"
+
+######################
+# Run tests          #
+######################
 cargo tarpaulin --tests --out Xml --exclude-files="src/core/testing/*"
 
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This commit fixes nightly issues:
Certain tests ran by coverage.sh require a mock service to have started before the tests are actually ran.

 * Clone and start the parsec-mock service for coverage testing.