### PR TITLE
ci/nightly: use actions/checkoutv2 for coverage builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
     name: Calculate coverage from tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           ref: "${{ github.event.inputs.rev }}"
       - name: Execute tarpaulin


### PR DESCRIPTION
While the rest of the tests use actions/checkout@v2, coverage builds currently uses v1.

 * Use actions/checkout@v2 instead of actions/checkout@v1