### PR TITLE
Cargo.toml: Specify rust-version=1.66.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["parsec"]
 categories = ["development-tools"]
 edition = "2018"
 documentation = "https://docs.rs/crate/parsec-client"
+rust-version = "1.66.0"
 
 [dependencies]
 parsec-interface = "0.29.0"


### PR DESCRIPTION
Mark MSRV (Minimum Supported Rust Version) as 1.66.0